### PR TITLE
update lightning/catalyst tutorials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,132 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# pytype cache
+.pytype/
+
+# mypy
+.mypy_cache/
+examples/scd_lvsegs.npz
+temp/
+.idea/
+
+*~
+
+# Remove .pyre temporary config files
+.pyre
+.pyre_configuration
+
+# temporary editor files that should not be in git
+*.orig
+*.bak
+*.swp
+.DS_Store
+
+# temporary testing data MedNIST
+tests/testing_data/MedNIST*
+tests/testing_data/*Hippocampus*
+
+# clang format tool
+.clang-format-bin/
+
+# VSCode
+.vscode/

--- a/3d_segmentation/spleen_segmentation_3d_lightning.ipynb
+++ b/3d_segmentation/spleen_segmentation_3d_lightning.ipynb
@@ -60,7 +60,7 @@
     }
    ],
    "source": [
-    "%pip install -qU \"monai[gdown, nibabel]\""
+    "%pip install -q \"monai[gdown, nibabel]\""
    ]
   },
   {
@@ -99,7 +99,7 @@
     }
    ],
    "source": [
-    "%pip install -q pytorch-lightning"
+    "%pip install -q pytorch-lightning==0.9.0"
    ]
   },
   {
@@ -477,7 +477,6 @@
     "    max_epochs=600,\n",
     "    logger=tb_logger,\n",
     "    checkpoint_callback=checkpoint_callback,\n",
-    "    show_progress_bar=False,\n",
     "    num_sanity_val_steps=1,\n",
     ")\n",
     "\n",

--- a/3d_segmentation/unet_segmentation_3d_catalyst.ipynb
+++ b/3d_segmentation/unet_segmentation_3d_catalyst.ipynb
@@ -22,7 +22,7 @@
     "* Sliding window inference method.\n",
     "* Deterministic training for reproducibility.\n",
     "\n",
-    "This tutorial is based on [unet_training_dict.py](https://github.com/Project-MONAI/MONAI/blob/master/examples/segmentation_3d/unet_training_dict.py) and [spleen_segmentation_3d.ipynb](https://github.com/Project-MONAI/Tutorials/blob/master/spleen_segmentation_3d.ipynb).\n",
+    "This tutorial is based on [unet_training_dict.py](https://github.com/Project-MONAI/tutorials/blob/master/3d_segmentation/torch/unet_training_dict.py) and [spleen_segmentation_3d.ipynb](https://github.com/Project-MONAI/Tutorials/blob/master/spleen_segmentation_3d.ipynb).\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/tutorials/blob/master/3d_segmentation/unet_segmentation_3d_catalyst.ipynb)"
    ]


### PR DESCRIPTION
part of #33 
adds a `.gitignore`
- pytorch lightning tutorial: 
    - trainer `show_progress_bar=False,` is deprecated, should be removed
    - it uses much more RAM compared with a vanilla training, perhaps there's a compatibility issue with CacheDataset?
- unet_segmentation_3d_catalyst: update a URL