### PR TITLE
Correct rotate_range and scale_range

### DIFF
--- a/3d_segmentation/challenge_baseline/run_net.py
+++ b/3d_segmentation/challenge_baseline/run_net.py
@@ -57,8 +57,8 @@ def get_xforms(mode="train", keys=("image", "label")):
                 RandAffined(
                     keys,
                     prob=0.15,
-                    rotate_range=(-0.05, 0.05),
-                    scale_range=(-0.1, 0.1),
+                    rotate_range=(0.05, 0.05, None),  # 3 parameters control the transform on 3 dimensions
+                    scale_range=(0.1, 0.1, None), 
                     mode=("bilinear", "nearest"),
                     as_tensor_output=False,
                 ),


### PR DESCRIPTION
The parameters of rotate_range and scale_range should be 3 values which tune the transform extent on 3 dimensions. And it's better to use 3 positive values to avoid  ambiguous meanings.