### PR TITLE
Update imports

### DIFF
--- a/2d_classification/mednist_tutorial.ipynb
+++ b/2d_classification/mednist_tutorial.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[pillow, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/3d_classification/torch/densenet_training_array.ipynb
+++ b/3d_classification/torch/densenet_training_array.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[nibabel, tqdm]"
+    "!python -c \"import monai\" || pip install -q \"monai[nibabel, tqdm]\""
    ]
   },
   {

--- a/3d_classification/torch/densenet_training_array.ipynb
+++ b/3d_classification/torch/densenet_training_array.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel, tqdm]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel, tqdm]\""
    ]
   },
   {

--- a/3d_segmentation/brats_segmentation_3d.ipynb
+++ b/3d_segmentation/brats_segmentation_3d.ipynb
@@ -53,7 +53,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/3d_segmentation/spleen_segmentation_3d.ipynb
+++ b/3d_segmentation/spleen_segmentation_3d.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[gdown, nibabel, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[gdown, nibabel, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/3d_segmentation/spleen_segmentation_3d_lightning.ipynb
+++ b/3d_segmentation/spleen_segmentation_3d_lightning.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "!python -c \"import pytorch_lightning\" || pip install -q pytorch-lightning==0.9.0\n",
     "%matplotlib inline"

--- a/3d_segmentation/unet_segmentation_3d_catalyst.ipynb
+++ b/3d_segmentation/unet_segmentation_3d_catalyst.ipynb
@@ -45,7 +45,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel, tensorboard]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel, tensorboard]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "!python -c \"import catalyst\" || pip install -q catalyst==20.07\n",
     "%matplotlib inline"

--- a/3d_segmentation/unet_segmentation_3d_ignite.ipynb
+++ b/3d_segmentation/unet_segmentation_3d_ignite.ipynb
@@ -24,7 +24,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[ignite, nibabel, tensorboard]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[ignite, nibabel, tensorboard]\""
    ]
   },
   {

--- a/3d_segmentation/unet_segmentation_3d_ignite.ipynb
+++ b/3d_segmentation/unet_segmentation_3d_ignite.ipynb
@@ -24,7 +24,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[ignite, nibabel, tensorboard]"
+    "!python -c \"import monai\" || pip install -q \"monai[ignite, nibabel, tensorboard]\""
    ]
   },
   {

--- a/acceleration/automatic_mixed_precision.ipynb
+++ b/acceleration/automatic_mixed_precision.ipynb
@@ -40,7 +40,7 @@
     }
    ],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/acceleration/dataset_type_performance.ipynb
+++ b/acceleration/dataset_type_performance.ipynb
@@ -35,7 +35,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[pillow, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/acceleration/fast_training_tutorial.ipynb
+++ b/acceleration/fast_training_tutorial.ipynb
@@ -42,7 +42,7 @@
     }
    ],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/acceleration/multi_gpu_test.ipynb
+++ b/acceleration/multi_gpu_test.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[ignite]"
+    "!python -c \"import monai\" || pip install -q \"monai[ignite]\""
    ]
   },
   {

--- a/acceleration/multi_gpu_test.ipynb
+++ b/acceleration/multi_gpu_test.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[ignite]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[ignite]\""
    ]
   },
   {

--- a/acceleration/threadbuffer_performance.ipynb
+++ b/acceleration/threadbuffer_performance.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[tqdm]"
+    "!python -c \"import monai\" || pip install -q \"monai[tqdm]\""
    ]
   },
   {

--- a/acceleration/threadbuffer_performance.ipynb
+++ b/acceleration/threadbuffer_performance.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[tqdm]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[tqdm]\""
    ]
   },
   {

--- a/acceleration/transform_speed.ipynb
+++ b/acceleration/transform_speed.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel]\""
    ]
   },
   {

--- a/acceleration/transform_speed.ipynb
+++ b/acceleration/transform_speed.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[nibabel]"
+    "!python -c \"import monai\" || pip install -q \"monai[nibabel]\""
    ]
   },
   {

--- a/modules/3d_image_transforms.ipynb
+++ b/modules/3d_image_transforms.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib"
    ]
   },

--- a/modules/autoencoder_mednist.ipynb
+++ b/modules/autoencoder_mednist.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[pillow, tqdm]"
+    "!python -c \"import monai\" || pip install -q \"monai[pillow, tqdm]\""
    ]
   },
   {

--- a/modules/autoencoder_mednist.ipynb
+++ b/modules/autoencoder_mednist.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[pillow, tqdm]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow, tqdm]\""
    ]
   },
   {

--- a/modules/dynunet_tutorial.ipynb
+++ b/modules/dynunet_tutorial.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel, ignite, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel, ignite, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/modules/integrate_3rd_party_transforms.ipynb
+++ b/modules/integrate_3rd_party_transforms.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "!python -c \"import batchgenerators\" || pip install -q batchgenerators==0.20.1\n",
     "!python -c \"import itk\" || pip install -q itk==5.1.0\n",

--- a/modules/interpretability/class_lung_lesion.ipynb
+++ b/modules/interpretability/class_lung_lesion.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[tqdm]"
+    "!python -c \"import monai\" || pip install -q \"monai[tqdm]\""
    ]
   },
   {

--- a/modules/interpretability/class_lung_lesion.ipynb
+++ b/modules/interpretability/class_lung_lesion.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[tqdm]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[tqdm]\""
    ]
   },
   {

--- a/modules/interpretability/covid_classification.ipynb
+++ b/modules/interpretability/covid_classification.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib"
    ]
   },

--- a/modules/layer_wise_learning_rate.ipynb
+++ b/modules/layer_wise_learning_rate.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[pillow, ignite, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow, ignite, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/modules/learning_rate.ipynb
+++ b/modules/learning_rate.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[pillow, tqdm]\n",
+    "!python -c \"import monai\" || pip install -q \"monai[pillow, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib"
    ]
   },

--- a/modules/learning_rate.ipynb
+++ b/modules/learning_rate.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[pillow, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib"
    ]
   },

--- a/modules/load_medical_images.ipynb
+++ b/modules/load_medical_images.ipynb
@@ -32,7 +32,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[itk, pillow]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[itk, pillow]\""
    ]
   },
   {

--- a/modules/load_medical_images.ipynb
+++ b/modules/load_medical_images.ipynb
@@ -32,7 +32,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[itk, pillow]"
+    "!python -c \"import monai\" || pip install -q \"monai[itk, pillow]\""
    ]
   },
   {

--- a/modules/mednist_GAN_tutorial.ipynb
+++ b/modules/mednist_GAN_tutorial.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai\n",
+    "!python -c \"import monai\" || pip install -q monai-weekly\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/modules/mednist_GAN_workflow_array.ipynb
+++ b/modules/mednist_GAN_workflow_array.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[ignite, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[ignite, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "\n",
     "%matplotlib inline"

--- a/modules/mednist_GAN_workflow_dict.ipynb
+++ b/modules/mednist_GAN_workflow_dict.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[ignite, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[ignite, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/modules/models_ensemble.ipynb
+++ b/modules/models_ensemble.ipynb
@@ -37,7 +37,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[ignite, nibabel, tqdm]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[ignite, nibabel, tqdm]\""
    ]
   },
   {

--- a/modules/models_ensemble.ipynb
+++ b/modules/models_ensemble.ipynb
@@ -37,7 +37,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[ignite, nibabel, tqdm]"
+    "!python -c \"import monai\" || pip install -q \"monai[ignite, nibabel, tqdm]\""
    ]
   },
   {

--- a/modules/nifti_read_example.ipynb
+++ b/modules/nifti_read_example.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel]\""
    ]
   },
   {

--- a/modules/nifti_read_example.ipynb
+++ b/modules/nifti_read_example.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[nibabel]"
+    "!python -c \"import monai\" || pip install -q \"monai[nibabel]\""
    ]
   },
   {

--- a/modules/post_transforms.ipynb
+++ b/modules/post_transforms.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[gdown, nibabel, skimage, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[gdown, nibabel, skimage, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/modules/public_datasets.ipynb
+++ b/modules/public_datasets.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[nibabel, pillow, ignite, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel, pillow, ignite, tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/modules/transforms_demo_2d.ipynb
+++ b/modules/transforms_demo_2d.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[pillow,tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow,tqdm]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]

--- a/modules/varautoencoder_mednist.ipynb
+++ b/modules/varautoencoder_mednist.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai[pillow]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow]\""
    ]
   },
   {

--- a/modules/varautoencoder_mednist.ipynb
+++ b/modules/varautoencoder_mednist.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q monai[pillow]"
+    "!python -c \"import monai\" || pip install -q \"monai[pillow]\""
    ]
   },
   {


### PR DESCRIPTION
Use `pip install monai-weekly` throughout. I think just before tagging versions (e.g. 0.5.0), we switch `pip install monai-weekly` to `pip install monai==0.5.0`, tag it, and then switch back. This will ensure that master branch uses a recent version of MONAI, and tagged versions remain fixed to a given release.

Something along lines of (untested and sed is BSD (OSX) version):

```bash
v=0.5.0
# weekly to fixed version
find . -name "*.ipynb" -exec sed -i '' 's|-q \\"monai-weekly\[|-q \\"monai==${v}\[|g' {} +
find . -name "*.ipynb" -exec sed -i '' 's|-q monai-weekly|-q monai==${v}|g' {} +
# commit
git commit -m 'fix version number for release'
# tag
git tag ${v}
# revert
git revert HEAD
```
