### PR TITLE
fixes default path

### DIFF
--- a/modules/interpretability/covid_classification.ipynb
+++ b/modules/interpretability/covid_classification.ipynb
@@ -114,9 +114,9 @@
    "outputs": [],
    "source": [
     "data_path_zip = os.path.join(os.environ.get(\n",
-    "    \"MONAI_DATA_DIRECTORY\"), \"archive.zip\")\n",
+    "    \"MONAI_DATA_DIRECTORY\", \".\"), \"archive.zip\")\n",
     "data_path = os.path.join(os.environ.get(\n",
-    "    \"MONAI_DATA_DIRECTORY\"), \"covid_xray_combined_small\")\n",
+    "    \"MONAI_DATA_DIRECTORY\", \".\"), \"covid_xray_combined_small\")\n",
     "if not os.path.isdir(data_path):\n",
     "    if not os.path.isfile(data_path_zip):\n",
     "        raise RuntimeError(\"TODO: Download needed.\")\n",


### PR DESCRIPTION
fixes os.path.join typeerror: TypeError: expected str, bytes or os.PathLike object, not NoneType
Signed-off-by: Wenqi Li <wenqil@nvidia.com>