### PR TITLE
Remove duplicate print config

### DIFF
--- a/modules/dynunet_pipeline/train.py
+++ b/modules/dynunet_pipeline/train.py
@@ -238,7 +238,6 @@ def train(args):
 
 
 if __name__ == "__main__":
-    print_config()
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument("-fold", "--fold", type=int, default=0, help="0-5")
     parser.add_argument(


### PR DESCRIPTION
Fixes # .

### Description
Remove duplicate `print_config` in dynunet tutorial.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`