### PR TITLE
Fix the print of logging in distributed programs

### DIFF
--- a/acceleration/distributed_training/unet_evaluation_workflows.py
+++ b/acceleration/distributed_training/unet_evaluation_workflows.py
@@ -82,6 +82,7 @@ from monai.transforms import (
 
 
 def evaluate(args):
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     if args.local_rank == 0 and not os.path.exists(args.dir):
         # create 16 random image, mask paris for evaluation
         print(f"generating synthetic data to {args.dir} (this may take a while)")
@@ -149,7 +150,6 @@ def evaluate(args):
         ),
     ]
     if dist.get_rank() == 0:
-        logging.basicConfig(stream=sys.stdout, level=logging.INFO)
         val_handlers.extend(
             [
                 StatsHandler(output_transform=lambda x: None),

--- a/acceleration/distributed_training/unet_training_workflows.py
+++ b/acceleration/distributed_training/unet_training_workflows.py
@@ -84,6 +84,7 @@ from monai.transforms import (
 
 
 def train(args):
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     if args.local_rank == 0 and not os.path.exists(args.dir):
         # create 40 random image, mask paris for training
         print(f"generating synthetic data to {args.dir} (this may take a while)")
@@ -160,7 +161,6 @@ def train(args):
         LrScheduleHandler(lr_scheduler=lr_scheduler, print_lr=True),
     ]
     if dist.get_rank() == 0:
-        logging.basicConfig(stream=sys.stdout, level=logging.INFO)
         train_handlers.extend(
             [
                 StatsHandler(tag_name="train_loss", output_transform=lambda x: x["loss"]),


### PR DESCRIPTION
### Description
This is a bug report from internal team that the latest MONAI code can't logging print log in this distributed program.
Maybe logging.basicConfig can't work well in subprocess group.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`