### PR TITLE
fixes #219

### DIFF
--- a/modules/TorchIO_MONAI_PyTorch_Lightning.ipynb
+++ b/modules/TorchIO_MONAI_PyTorch_Lightning.ipynb
@@ -61,9 +61,9 @@
    "source": [
     "%%bash\n",
     "pip install -q torchio==0.18.39\n",
-    "pip install -q monai==0.5.2\n",
+    "pip install -q \"monai[gdown]\"==0.5.2\n",
     "pip install -q pytorch-lightning==1.2.10\n",
-    "pip install -q gdown==3.6.4 matplotlib==3.2.2 pandas==1.1.5 seaborn==0.11.1"
+    "pip install -q pandas==1.1.5 seaborn==0.11.1"
    ]
   },
   {
@@ -588,8 +588,6 @@
     "    for batch in data.test_dataloader():\n",
     "        inputs = batch['image'][tio.DATA].to(model.device)\n",
     "        labels = model.net(inputs).argmax(dim=1, keepdim=True).cpu()\n",
-    "        for i in range(len(inputs)):\n",
-    "            break\n",
     "        break\n",
     "batch_subjects = tio.utils.get_subjects_from_batch(batch)\n",
     "tio.utils.add_images_from_batch(batch_subjects, labels, tio.LabelMap)"

--- a/runner.sh
+++ b/runner.sh
@@ -28,6 +28,7 @@ doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" transforms_demo_2d.
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" nifti_read_example.ipynb)
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" 3d_image_transforms.ipynb)
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" mednist_classifier_ray.ipynb)
+doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" TorchIO_MONAI_PyTorch_Lightning.ipynb)
 
 
 # output formatting


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #219 

additionally, it seems `matplotlib==3.2.2` would break some other tutorials, so this line is removed

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`