### PR TITLE
233 Update to use latest metrics API and add compute_metric example

### DIFF
--- a/3d_segmentation/torch/compute_metric.py
+++ b/3d_segmentation/torch/compute_metric.py
@@ -1,0 +1,113 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example shows how to compute metric in multi-processing based on PyTorch native `DistributedDataParallel` module.
+It can run on several nodes with multiple GPU devices on every node.
+Main steps to set up the distributed data parallel:
+
+- Execute `torch.distributed.launch` to create processes on every node for every GPU.
+  It receives parameters as below:
+  `--nproc_per_node=NUM_GPUS_PER_NODE`
+  `--nnodes=NUM_NODES`
+  `--node_rank=INDEX_CURRENT_NODE`
+  `--master_addr="localhost"`
+  `--master_port=1234`
+  For more details, refer to https://github.com/pytorch/pytorch/blob/master/torch/distributed/launch.py.
+  Alternatively, we can also use `torch.multiprocessing.spawn` to start program, but it that case, need to handle
+  all the above parameters and compute `rank` manually, then set to `init_process_group`, etc.
+  `torch.distributed.launch` is even more efficient than `torch.multiprocessing.spawn`.
+- Use `init_process_group` to initialize every process, every GPU runs in a separate process with unique rank.
+  Here we use `NVIDIA NCCL` as the backend and must set `init_method="env://"` if use `torch.distributed.launch`.
+- Partition the saved predictions and labels into ranks for parallel computation.
+- Compute `Dice Metric` on every process, reduce the results after synchronization.
+
+Note:
+    `torch.distributed.launch` will launch `nnodes * nproc_per_node = world_size` processes in total.
+    Suggest setting exactly the same software environment for every node, especially `PyTorch`, `nccl`, etc.
+    A good practice is to use the same MONAI docker image for all nodes directly.
+    Example script to execute this program on every node:
+    python -m torch.distributed.launch --nproc_per_node=NUM_GPUS_PER_NODE
+           --nnodes=NUM_NODES --node_rank=INDEX_CURRENT_NODE
+           --master_addr="localhost" --master_port=1234
+           compute_metric.py
+
+    This example was tested with [Ubuntu 16.04/20.04], [NCCL 2.6.3].
+
+Referring to: https://pytorch.org/tutorials/intermediate/ddp_tutorial.html
+
+"""
+
+import argparse
+import os
+from glob import glob
+
+import nibabel as nib
+import numpy as np
+import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel
+
+import monai
+from monai.data import DataLoader, Dataset, partition_dataset
+from monai.inferers import sliding_window_inference
+from monai.metrics import DiceMetric
+from monai.transforms import EnsureChannelFirstd, Compose, LoadImaged, ToTensord
+
+
+def compute(args):
+    # initialize the distributed evaluation process, every GPU runs in a process
+    dist.init_process_group(backend="nccl", init_method="env://")
+
+    preds = sorted(glob(os.path.join(args.dir, "img*", "img*.nii.gz")))
+    labels = sorted(glob(os.path.join(args.dir, "seg*.nii.gz")))
+    datalist = [{"pred": pred, "label": label} for pred, label in zip(preds, labels)]
+
+    # split data for every subprocess, for example, 16 processes compute in parallel
+    data_part = partition_dataset(
+        data=datalist,
+        num_partitions=dist.get_world_size(),
+        shuffle=False,
+        even_divisible=False,
+    )[dist.get_rank()]
+
+    # define transforms for predictions and labels
+    transforms = Compose(
+        [
+            LoadImaged(keys=["pred", "label"]),
+            EnsureChannelFirstd(keys=["pred", "label"]),
+            ToTensord(keys=["pred", "label"]),
+        ]
+    )
+    data_part = [transforms(item) for item in data_part]
+
+    # compute metrics for current process
+    metric = DiceMetric(ignore_background=True, reduction="mean")
+    metric(y_pred=data_part["pred"], y=data_part["label"])
+    # all-gather results from all the processes and reduce for final result
+    print("mean dice: ", metric.aggregate().item())
+    metric.reset()
+
+    dist.destroy_process_group()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--dir", default="./output", type=str, help="root directory of labels and predictions.")
+    # must parse the command-line argument: ``--local_rank=LOCAL_PROCESS_RANK``, which will be provided by DDP
+    parser.add_argument("--local_rank", type=int)
+    args = parser.parse_args()
+
+    compute(args=args)
+
+
+if __name__ == "__main__":
+    main()

--- a/3d_segmentation/torch/unet_evaluation_dict.py
+++ b/3d_segmentation/torch/unet_evaluation_dict.py
@@ -60,7 +60,7 @@ def main(tempdir):
     val_ds = monai.data.Dataset(data=val_files, transform=val_transforms)
     # sliding window inference need to input 1 image in every iteration
     val_loader = DataLoader(val_ds, batch_size=1, num_workers=4, collate_fn=list_data_collate)
-    dice_metric = DiceMetric(include_background=True, reduction="mean")
+    dice_metric = DiceMetric(include_background=True, reduction="mean", get_not_nans=False)
     post_trans = Compose([Activations(sigmoid=True), AsDiscrete(threshold_values=True)])
     # try to use all the available GPUs
     devices = get_devices_spec(None)

--- a/3d_segmentation/torch/unet_evaluation_dict.py
+++ b/3d_segmentation/torch/unet_evaluation_dict.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import logging
 import os
 import sys
@@ -99,15 +98,5 @@ def main(tempdir):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-s", "--save_synthetic_data", default=False, type=bool, help="whether to save generated images and labels."
-    )
-    args = parser.parse_args()
-    if args.save_synthetic_data:
-        output_dir = "./output"
-        os.makedirs(output_dir, exist_ok=True)
-        main(output_dir)
-    else:
-        with tempfile.TemporaryDirectory() as tempdir:
-            main(tempdir)
+    with tempfile.TemporaryDirectory() as tempdir:
+        main(tempdir)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The examples are standard PyTorch programs and have both dictionary-based and ar
 Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.
 The examples are PyTorch Ignite programs and have both dictionary-base and array-based transformations.
 #### [torch examples](./3d_segmentation/torch)
-Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.
+Training, evaluation, inference and metrics computation examples of 3D segmentation based on UNet3D and synthetic dataset.
 The examples are standard PyTorch programs and have both dictionary-based and array-based versions.
 #### [brats_segmentation_3d](./3d_segmentation/brats_segmentation_3d.ipynb)
 This tutorial shows how to construct a training workflow of multi-labels segmentation task based on [MSD Brain Tumor dataset](http://medicaldecathlon.com).

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The examples are standard PyTorch programs and have both dictionary-based and ar
 Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.
 The examples are PyTorch Ignite programs and have both dictionary-base and array-based transformations.
 #### [torch examples](./3d_segmentation/torch)
-Training, evaluation, inference and metrics computation examples of 3D segmentation based on UNet3D and synthetic dataset.
+Training, evaluation and inference examples of 3D segmentation based on UNet3D and synthetic dataset.
 The examples are standard PyTorch programs and have both dictionary-based and array-based versions.
 #### [brats_segmentation_3d](./3d_segmentation/brats_segmentation_3d.ipynb)
 This tutorial shows how to construct a training workflow of multi-labels segmentation task based on [MSD Brain Tumor dataset](http://medicaldecathlon.com).
@@ -167,6 +167,8 @@ This notebook demonstrates the transformations on volumetric images.
 #### [autoencoder_mednist](./modules/autoencoder_mednist.ipynb)
 This tutorial uses the MedNIST hand CT scan dataset to demonstrate MONAI's autoencoder class. The autoencoder is used with an identity encode/decode (i.e., what you put in is what you should get back), as well as demonstrating its usage for de-blurring and de-noising.
 
+#### [compute_metric](./modules/compute_metric.py)
+Example shows how to compute metrics from saved predictions and labels with PyTorch multi-processing support.
 #### [dynunet_tutorial](./modules/dynunet_pipeline)
 This tutorial shows how to train 3D segmentation tasks on all the 10 decathlon datasets with the reimplementation of dynUNet in MONAI.
 #### [integrate_3rd_party_transforms](./modules/integrate_3rd_party_transforms.ipynb)

--- a/modules/compute_metric.py
+++ b/modules/compute_metric.py
@@ -10,7 +10,8 @@
 # limitations under the License.
 
 """
-This example shows how to compute metric in multi-processing based on PyTorch native `DistributedDataParallel` module.
+This example shows how to efficiently compute Dice scores for pairs of segmentation prediction
+and references in multi-processing based on MONAI's metrics API.
 It can even run on multi-nodes.
 Main steps to set up the distributed data parallel:
 
@@ -32,8 +33,7 @@ Main steps to set up the distributed data parallel:
 Note:
     `torch.distributed.launch` will launch `nnodes * nproc_per_node = world_size` processes in total.
     Example script to execute this program on a single node with 2 processes:
-    python -m torch.distributed.launch --nproc_per_node=2 --nnodes=1 --node_rank=0
-           --master_addr="localhost" --master_port=1234 compute_metric.py
+    `python -m torch.distributed.launch --nproc_per_node=2 compute_metric.py`
 
 Referring to: https://pytorch.org/tutorials/intermediate/ddp_tutorial.html
 
@@ -115,7 +115,7 @@ def compute(args):
 
     if args.local_rank == 0:
         print("mean dice: ", result)
-        # generate metric report
+        # generate metrics reports at: output/mean_dice_raw.csv, output/mean_dice_summary.csv, output/metrics.csv
         write_metrics_reports(
             save_dir="./output",
             images=filenames,

--- a/modules/compute_metric.py
+++ b/modules/compute_metric.py
@@ -50,16 +50,11 @@ import argparse
 import os
 from glob import glob
 
-import nibabel as nib
-import numpy as np
 import torch
 import torch.distributed as dist
-from torch.nn.parallel import DistributedDataParallel
 
-import monai
-from monai.data import DataLoader, Dataset, partition_dataset
+from monai.data import partition_dataset
 from monai.handlers import write_metrics_reports
-from monai.inferers import sliding_window_inference
 from monai.metrics import DiceMetric
 from monai.transforms import EnsureChannelFirstd, Compose, LoadImaged, ToTensord
 from monai.utils import string_list_all_gather


### PR DESCRIPTION
Fixes #233 .

### Description
This PR updated the 3D segmentation examples to show how to use latest metrics APIs (@yiheng-wang-nv will help update all the other examples and tutorials later.)
And also added example to compute metrics based on saved predictions and labels with multi-processing, and generate the metrics report.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`