### PR TITLE
update tutorial for LMDB dataset usage

### DIFF
--- a/modules/transfer_mmar.ipynb
+++ b/modules/transfer_mmar.ipynb
@@ -424,14 +424,16 @@
    ],
    "source": [
     "train_ds = LMDBDataset(data=train_files, transform=train_transforms, cache_dir=root_dir)\n",
+    "print(train_ds.info())\n",
     "\n",
     "# use batch_size=2 to load images and use RandCropByPosNegLabeld\n",
     "# to generate 2 x 4 images for network training\n",
     "train_loader = DataLoader(train_ds, batch_size=2, shuffle=True, num_workers=2)\n",
     "\n",
-    "val_ds = LMDBDataset(data=val_files, transform=val_transforms, cache_dir=root_dir)\n",
     "# the validation data loader will be created on the fly to ensure \n",
-    "# a deterministic validation set for demo purpose."
+    "# a deterministic validation set for demo purpose.\n",
+    "val_ds = LMDBDataset(data=val_files, transform=val_transforms, cache_dir=root_dir)\n",
+    "print(val_ds.info())"
    ]
   },
   {


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
`train_ds.info()` will trigger the cache loading, so that the cache is ready before the dataloader calls.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`