### PR TITLE
Update decollate tutorial to use `EnsureTyped`

### DIFF
--- a/modules/decollate_batch.ipynb
+++ b/modules/decollate_batch.ipynb
@@ -76,11 +76,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MONAI version: 0.4.0+540.g8803885\n",
+      "MONAI version: 0.4.0+544.g5e7345d\n",
       "Numpy version: 1.21.0\n",
       "Pytorch version: 1.9.0+cu102\n",
       "MONAI flags: HAS_EXT = False, USE_COMPILED = False\n",
-      "MONAI rev id: 88038854f6cd256989695c2368e3ee9fca213e8d\n",
+      "MONAI rev id: 5e7345d384ae08011b0e250b93f615d6d5190258\n",
       "\n",
       "Optional dependencies:\n",
       "Pytorch Ignite version: 0.4.5\n",
@@ -134,6 +134,7 @@
     "from monai.transforms import (\n",
     "    Activationsd,\n",
     "    EnsureChannelFirstd,\n",
+    "    EnsureTyped,\n",
     "    AsDiscreted,\n",
     "    Compose,\n",
     "    Invertd,\n",
@@ -142,7 +143,6 @@
     "    Resized,\n",
     "    SaveImaged,\n",
     "    ScaleIntensityd,\n",
-    "    ToTensord,\n",
     ")\n",
     "from monai.utils import set_determinism\n",
     "\n",
@@ -248,7 +248,7 @@
     "        Orientationd(keys=\"img\", axcodes=\"RAS\"),\n",
     "        Resized(keys=\"img\", spatial_size=(96, 96, 96), mode=\"trilinear\", align_corners=True),\n",
     "        ScaleIntensityd(keys=\"img\"),\n",
-    "        ToTensord(keys=[\"img\", \"seg\"]),\n",
+    "        EnsureTyped(keys=[\"img\", \"seg\"]),\n",
     "    ]\n",
     ")\n",
     "dataset = Dataset(data=files, transform=preprocessing)\n",
@@ -262,12 +262,12 @@
     "## Setup postprocessing transforms, metrics\n",
     "Here we try to invert the preprocessing predictions for `pred` and save into Nifti files.\n",
     "\n",
-    "As all the post processing transforms expect `Tensor` input, apply `ToTensord` first to ensure the data type after `decollate_batch`."
+    "As all the post processing transforms expect `Tensor` input, apply `EnsureTyped` first to ensure the data type after `decollate_batch`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
@@ -275,7 +275,7 @@
    "source": [
     "postprocessing = Compose(\n",
     "    [\n",
-    "        ToTensord(keys=[\"pred\", \"seg\"]),  # ensure Tensor type after `decollate`\n",
+    "        EnsureTyped(keys=[\"pred\", \"seg\"]),  # ensure Tensor type after `decollate`\n",
     "        Activationsd(keys=\"pred\", sigmoid=True),\n",
     "        Invertd(\n",
     "            keys=\"pred\",  # invert the `pred` data field, also support multiple fields\n",
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "metadata": {
     "pycharm": {
      "is_executing": true


### PR DESCRIPTION
### Description
This PR updated the decollate tutorial to use `EnsureTyped` transform according to our discussion:
https://github.com/Project-MONAI/MONAI/pull/2494#issuecomment-872968095

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`