### PR TITLE
265 Add csv_datasets.ipynb to runner.sh

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -31,6 +31,7 @@ doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" mednist_classifier_
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" TorchIO_MONAI_PyTorch_Lightning.ipynb)
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" image_dataset.ipynb)
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" decollate_batch.ipynb)
+doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" csv_datasets.ipynb)
 
 
 # output formatting


### PR DESCRIPTION
Fixes #265 .

### Description
This PR fixed the cron test by adding `csv_datasets.ipynb` to runner.sh.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`