### PR TITLE
264 fix inverse example error

### DIFF
--- a/modules/inverse_transforms_and_test_time_augmentations.ipynb
+++ b/modules/inverse_transforms_and_test_time_augmentations.ipynb
@@ -445,7 +445,7 @@
     "def infer_seg(images, model, roi_size=(96, 96), sw_batch_size=4):\n",
     "    val_outputs = sliding_window_inference(\n",
     "        images, roi_size, sw_batch_size, model)\n",
-    "    return [post_trans(i) for i in decollate_batch(val_outputs)]\n",
+    "    return torch.stack([post_trans(i) for i in decollate_batch(val_outputs)])\n",
     "\n",
     "\n",
     "# Create network, loss fn., etc.\n",


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #264 .

### Description
As for the two errors mentioned in #264 , this PR fixes the inverse example one and the other has been fixed in #259 

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`