### PR TITLE
fix minor description typo in UNETR tutorial

### DIFF
--- a/3d_segmentation/unetr_btcv_segmentation_3d.ipynb
+++ b/3d_segmentation/unetr_btcv_segmentation_3d.ipynb
@@ -17,7 +17,7 @@
     "1. Load Nifti image with metadata, load a list of images and stack them.\n",
     "1. Randomly adjust intensity for data augmentation.\n",
     "1. Cache IO and transforms to accelerate training and validation.\n",
-    "1. 3D UNETR model, Dice loss function, Mean Dice metric for multi-oorgan segmentation task.\n",
+    "1. 3D UNETR model, DiceCE loss function, Mean Dice metric for multi-organ segmentation task.\n",
     "\n",
     "The dataset comes from https://www.synapse.org/#!Synapse:syn3193805/wiki/217752.  \n",
     "\n",


### PR DESCRIPTION
Signed-off-by: ahatamizadeh <ahatamizadeh@nvidia.com>

Fixes #273 

### Description
This PR fixes a minor description typo in UNETR tutorial.

### Status
Ready

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Notebook runs automatically `./runner [-p <regex_pattern>]`