### PR TITLE
workaround for #308 ignore profiling_camelyon_pipeline

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -55,7 +55,7 @@ doChecks=true
 doRun=true
 autofix=false
 failfast=false
-pattern="-and -name '*' -and ! -wholename '*federated_learning*' -and ! -wholename '*unetr_btcv*'"
+pattern="-and -name '*' -and ! -wholename '*federated_learning*' -and ! -wholename '*unetr_btcv*' -and ! -wholename '*profiling_camelyon*'"
 kernelspec="python3"
 
 function print_usage {


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

workaround for #308

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`