### PR TITLE
update for monai 0.7

### DIFF
--- a/3d_segmentation/unet_segmentation_3d_catalyst.ipynb
+++ b/3d_segmentation/unet_segmentation_3d_catalyst.ipynb
@@ -475,7 +475,7 @@
    },
    "outputs": [],
    "source": [
-    "max_epochs = 600\n",
+    "max_epochs = 50\n",
     "val_interval = 2\n",
     "log_dir = os.path.join(root_dir, \"logs\")\n",
     "runner = MonaiSupervisedRunner(\n",
@@ -664,7 +664,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/acceleration/distributed_training/brats_training_ddp.py
+++ b/acceleration/distributed_training/brats_training_ddp.py
@@ -16,6 +16,10 @@ It can run on several nodes with multiple GPU devices on every node.
 This example is a real-world task based on Decathlon challenge Task01: Brain Tumor segmentation.
 So it's more complicated than other distributed training demo examples.
 
+Under default settings, each single GPU needs to use ~12GB memory for network training. In addition, in order to
+cache the whole dataset, ~100GB GPU memory are necessary. Therefore, at least 5 NVIDIA TESLA V100 (32G) are needed.
+If you do not have enough GPU memory, you can try to decrease the input parameter `cache_rate`.
+
 Main steps to set up the distributed training:
 
 - Execute `torch.distributed.launch` to create processes on every node for every GPU.
@@ -372,9 +376,9 @@ def main():
     parser.add_argument("--local_rank", type=int, help="node rank for distributed training")
     parser.add_argument("--epochs", default=300, type=int, metavar="N", help="number of total epochs to run")
     parser.add_argument("--lr", default=1e-4, type=float, help="learning rate")
-    parser.add_argument("-b", "--batch_size", default=2, type=int, help="mini-batch size of every GPU")
+    parser.add_argument("-b", "--batch_size", default=1, type=int, help="mini-batch size of every GPU")
     parser.add_argument("--seed", default=None, type=int, help="seed for initializing training.")
-    parser.add_argument("--cache_rate", type=float, default=1.0)
+    parser.add_argument("--cache_rate", type=float, default=1.0, help="larger cache rate relies on enough GPU memory.")
     parser.add_argument("--val_interval", type=int, default=20)
     parser.add_argument("--network", type=str, default="SegResNet", choices=["UNet", "SegResNet"])
     args = parser.parse_args()

--- a/modules/dynunet_pipeline/train.py
+++ b/modules/dynunet_pipeline/train.py
@@ -227,11 +227,10 @@ def train(args):
 
     logger.addHandler(fhandler)
 
-    if not multi_gpu_flag:
-        chandler = logging.StreamHandler()
-        chandler.setLevel(logging.INFO)
-        chandler.setFormatter(formatter)
-        logger.addHandler(chandler)
+    chandler = logging.StreamHandler()
+    chandler.setLevel(logging.INFO)
+    chandler.setFormatter(formatter)
+    logger.addHandler(chandler)
 
     logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

This PR modifies some notebooks:

1. For `unet_segmentation_3d_catalyst.ipynb`, 600 epochs are unnecessary for synthetic images training.
2. For `brats_training_ddp.py`, the default settings need to take huge computing resources, I added some comments to show the relationship between gpu memories and cache rate.
3. For dynunet pipeline, I did a few change in order to show logs correctly in multi-gpu mode.

I checked all notebooks (except `pathology`, `deployment` and `federated_learning`) under this commit: https://github.com/Project-MONAI/MONAI/commit/ecbb03bedbf5839660d15ee61c18795e9cf0d6ab  and they all work fine.

I will check `pathology` when doing another task, and I will update `federated_learning/nvflare` after monai 0.7.0 released (in order to use the latest API).

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
