### PR TITLE
fixes runner script

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -56,7 +56,7 @@ doChecks=true
 doRun=true
 autofix=false
 failfast=false
-pattern="-and -name '*' -and ! -wholename '*federated_learning*' -and ! -wholename '*unetr_btcv*' -and ! -wholename '*profiling_camelyon*'"
+pattern="-and -name '*' -and ! -wholename '*federated_learning*' -and ! -wholename '*unetr_btcv*' -and ! -wholename '*profiling_camelyon*' -and ! -wholename '*profiling_train_base_nvtx*'"
 kernelspec="python3"
 
 function print_usage {


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

excluding `profiling_train_base_nvtx` notebook from auto tests


### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
