### PR TITLE
Add missing dependency to deepgrow notebook

### DIFF
--- a/deepgrow/ignite/inference_3d.ipynb
+++ b/deepgrow/ignite/inference_3d.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai-weekly[gdown, tqdm]\""
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[gdown, nibabel, tqdm]\""
    ]
   },
   {


### PR DESCRIPTION
Fixes #419 

### Description

Add dependency to `nibabel` so that it is possible to read `nii.gz` images

### Status
**Ready**

### Testing details:

Run `# Pre Processing` cell and verify that the image is loaded correctly:

```
LoadImaged => image shape: (392, 392, 210)
Guidance: [[[145, 66, 180], [105, 66, 180]], []]; Slice Idx: 145
```
