### PR TITLE
Update spleen_segmentation_3d.ipynb: add pytorch-ignite in pip install

### DIFF
--- a/3d_segmentation/spleen_segmentation_3d.ipynb
+++ b/3d_segmentation/spleen_segmentation_3d.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -q \"monai-weekly[gdown, nibabel, tqdm]\"\n",
+    "!python -c \"import monai\" || pip install -q \"monai-weekly[gdown, nibabel, tqdm, ignite]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]


### PR DESCRIPTION
Fixes import errors due to missing pytorch-ignite package.

### Description
The `pip install` statement is missing the installation of pytorch-ignite. This causes import errors in the next cell, specifically in the line: 
`from monai.handlers.utils import from_engine`. 

This change fixes the problem:. From:
`!python -c "import monai" || pip install -q "monai-weekly[gdown, nibabel, tqdm]"`
to 
`!python -c "import monai" || pip install -q "monai-weekly[gdown, nibabel, tqdm, ignite]"`

### Status
**Ready**

### Checks
Checked and working in Google Colab. 