### PR TITLE
update class_lung_lesion.ipynb

### DIFF
--- a/modules/interpretability/class_lung_lesion.ipynb
+++ b/modules/interpretability/class_lung_lesion.ipynb
@@ -636,7 +636,7 @@
     "n_examples = 5\n",
     "subplot_shape = [3, n_examples]\n",
     "fig, axes = plt.subplots(*subplot_shape, figsize=(25, 15), facecolor=\"white\")\n",
-    "items = np.random.choice(len(train_ds), size=len(train_ds))\n",
+    "items = np.random.choice(len(train_ds), size=len(train_ds), replace=False)\n",
     "\n",
     "example = 0\n",
     "for item in items:\n",


### PR DESCRIPTION
Added replace=False in the explainability cause we don't want to investigate a sample more than once

Fixes # .

### Description
when choosing the samples to explain, we don't want to explain a sample more than once

### Status
**Ready/Work in progress/Hold**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
