### PR TITLE
508 fix lightning issue and update to 1.5.8

### DIFF
--- a/3d_segmentation/spleen_segmentation_3d_lightning.ipynb
+++ b/3d_segmentation/spleen_segmentation_3d_lightning.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "!python -c \"import monai\" || pip install -q \"monai-weekly[nibabel]\"\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
-    "!pip install -q pytorch-lightning==1.4.0\n",
+    "!pip install -q pytorch-lightning==1.5.8\n",
     "%matplotlib inline"
    ]
   },
@@ -121,6 +121,7 @@
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License.\n",
     "\n",
+    "import pytorch_lightning\n",
     "from monai.utils import set_determinism\n",
     "from monai.transforms import (\n",
     "    AsDiscrete,\n",
@@ -144,7 +145,6 @@
     "from monai.config import print_config\n",
     "from monai.apps import download_and_extract\n",
     "import torch\n",
-    "import pytorch_lightning\n",
     "import matplotlib.pyplot as plt\n",
     "import tempfile\n",
     "import shutil\n",
@@ -428,8 +428,9 @@
     "    gpus=[0],\n",
     "    max_epochs=600,\n",
     "    logger=tb_logger,\n",
-    "    checkpoint_callback=True,\n",
+    "    enable_checkpointing=True,\n",
     "    num_sanity_val_steps=1,\n",
+    "    log_every_n_steps=16,\n",
     ")\n",
     "\n",
     "# train\n",


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #508 .

### Description
The issue comes from `transformers` and `pytorch_lightning` sides, where the latest version of `transformers` (4.15.0) may have an issue that `transformers.models.auto.__spec__` is None (see also here: https://github.com/huggingface/transformers/issues/15212), and `pytorch_lightning` requires that should not be None.

Although the tutorial does not use `transformers` directly, it imports `monai` which includes the info of `transformers` (if `transformers` has installed).

Since the issue has not been fixed in `transformers`, my temporary method in this PR is to import `pytorch_lightning` at the beginning (before import `monai`) to avoid the issue.

In addition, this PR also updates the lightning version into the latest `1.5.8` and enhances a few places of its API usages.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
