### PR TITLE
Add `get_logger` and StatsHandler example code

### DIFF
--- a/modules/engines/unet_evaluation_dict.py
+++ b/modules/engines/unet_evaluation_dict.py
@@ -96,6 +96,7 @@ def main(tempdir):
         ]
     )
     val_handlers = [
+        # use the logger "eval_log" defined at the beginning of this program
         StatsHandler(name="eval_log", output_transform=lambda x: None),
         CheckpointLoader(load_path=model_file, load_dict={"net": net}),
     ]

--- a/modules/engines/unet_evaluation_dict.py
+++ b/modules/engines/unet_evaluation_dict.py
@@ -21,9 +21,10 @@ import torch
 from ignite.metrics import Accuracy
 
 import monai
+from monai.apps import get_logger
 from monai.data import create_test_image_3d
 from monai.engines import SupervisedEvaluator
-from monai.handlers import CheckpointLoader, MeanDice, SegmentationSaver, StatsHandler, from_engine
+from monai.handlers import CheckpointLoader, MeanDice, StatsHandler, from_engine
 from monai.inferers import SlidingWindowInferer
 from monai.transforms import (
     Activationsd,
@@ -40,7 +41,9 @@ from monai.transforms import (
 
 def main(tempdir):
     monai.config.print_config()
+    # set root log level to INFO and init a evaluation logger, will be used in `StatsHandler`
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    get_logger("eval_log")
 
     # create a temporary directory and 40 random image, mask pairs
     print(f"generating synthetic data to {tempdir} (this may take a while)")
@@ -93,7 +96,7 @@ def main(tempdir):
         ]
     )
     val_handlers = [
-        StatsHandler(output_transform=lambda x: None),
+        StatsHandler(name="eval_log", output_transform=lambda x: None),
         CheckpointLoader(load_path=model_file, load_dict={"net": net}),
     ]
 

--- a/modules/engines/unet_training_dict.py
+++ b/modules/engines/unet_training_dict.py
@@ -21,6 +21,7 @@ import torch
 from ignite.metrics import Accuracy
 
 import monai
+from monai.apps import get_logger
 from monai.data import create_test_image_3d
 from monai.engines import SupervisedEvaluator, SupervisedTrainer
 from monai.handlers import (
@@ -50,7 +51,9 @@ from monai.transforms import (
 
 def main(tempdir):
     monai.config.print_config()
+    # set root log level to INFO and init a train logger, will be used in `StatsHandler`
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    get_logger("train_log")
 
     # create a temporary directory and 40 random image, mask pairs
     print(f"generating synthetic data to {tempdir} (this may take a while)")
@@ -119,7 +122,7 @@ def main(tempdir):
         ]
     )
     val_handlers = [
-        StatsHandler(output_transform=lambda x: None),
+        StatsHandler(name="train_log", output_transform=lambda x: None),
         TensorBoardStatsHandler(log_dir="./runs/", output_transform=lambda x: None),
         TensorBoardImageHandler(
             log_dir="./runs/",
@@ -154,7 +157,7 @@ def main(tempdir):
     train_handlers = [
         LrScheduleHandler(lr_scheduler=lr_scheduler, print_lr=True),
         ValidationHandler(validator=evaluator, interval=2, epoch_level=True),
-        StatsHandler(tag_name="train_loss", output_transform=from_engine(["loss"], first=True)),
+        StatsHandler(name="train_log", tag_name="train_loss", output_transform=from_engine(["loss"], first=True)),
         TensorBoardStatsHandler(log_dir="./runs/", tag_name="train_loss", output_transform=from_engine(["loss"], first=True)),
         CheckpointSaver(save_dir="./runs/", save_dict={"net": net, "opt": opt}, save_interval=2, epoch_level=True),
     ]

--- a/modules/engines/unet_training_dict.py
+++ b/modules/engines/unet_training_dict.py
@@ -122,6 +122,7 @@ def main(tempdir):
         ]
     )
     val_handlers = [
+        # use the logger "train_log" defined at the beginning of this program
         StatsHandler(name="train_log", output_transform=lambda x: None),
         TensorBoardStatsHandler(log_dir="./runs/", output_transform=lambda x: None),
         TensorBoardImageHandler(
@@ -157,6 +158,7 @@ def main(tempdir):
     train_handlers = [
         LrScheduleHandler(lr_scheduler=lr_scheduler, print_lr=True),
         ValidationHandler(validator=evaluator, interval=2, epoch_level=True),
+        # use the logger "train_log" defined at the beginning of this program
         StatsHandler(name="train_log", tag_name="train_loss", output_transform=from_engine(["loss"], first=True)),
         TensorBoardStatsHandler(log_dir="./runs/", tag_name="train_loss", output_transform=from_engine(["loss"], first=True)),
         CheckpointSaver(save_dir="./runs/", save_dict={"net": net, "opt": opt}, save_interval=2, epoch_level=True),


### PR DESCRIPTION
### Description
This PR added usage example of `get_logger` to show the latest design of MONAI `StatsHandler`, users can prepare `logger` outside or use the default ignite `engine.logger`.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
