### PR TITLE
530 fix torchtext error

### DIFF
--- a/modules/TorchIO_MONAI_PyTorch_Lightning.ipynb
+++ b/modules/TorchIO_MONAI_PyTorch_Lightning.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q torch==1.10.2"
+    "%pip install -q torch==1.10.2 torchtext torchvision"
    ]
   },
   {
@@ -85,8 +85,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "pip install -q torchio==0.18.39\n",
-    "pip install -q pytorch-lightning==1.5.8\n",
+    "pip install -q torchio==0.18.73\n",
+    "pip install -q pytorch-lightning==1.5.10\n",
     "pip install -q pandas==1.1.5 seaborn==0.11.1"
    ]
   },
@@ -239,13 +239,13 @@
     "        self.test_set = tio.SubjectsDataset(self.test_subjects, transform=self.preprocess)\n",
     "\n",
     "    def train_dataloader(self):\n",
-    "        return DataLoader(self.train_set, self.batch_size)\n",
+    "        return DataLoader(self.train_set, self.batch_size, num_workers=2)\n",
     "\n",
     "    def val_dataloader(self):\n",
-    "        return DataLoader(self.val_set, self.batch_size)\n",
+    "        return DataLoader(self.val_set, self.batch_size, num_workers=2)\n",
     "\n",
     "    def test_dataloader(self):\n",
-    "        return DataLoader(self.test_set, self.batch_size)"
+    "        return DataLoader(self.test_set, self.batch_size, num_workers=2)"
    ]
   },
   {
@@ -254,7 +254,8 @@
     "id": "WwJwFaZxolI7"
    },
    "source": [
-    "We will use a batch size of 16 and 20% of the training data for validation."
+    "We will use a batch size of 16 and 20% of the training data for validation.\n",
+    "`num_workers` is set to 2 in default, you may need to modify the value to optimize training."
    ]
   },
   {


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #530 .

### Description

This PR fixes the error:
`ImportError: /opt/conda/lib/python3.8/site-packages/torchtext/_torchtext.so: undefined symbol: _ZNK3c104Type14isSubtypeOfExtERKS0_PSo` which is due to the version of `torchtext` and `torch` mismatch.

However, even with the latest release of `pytorch-lightning==1.5.10` and `torchio==0.18.73`, using `torch=1.11.0a0+bfe5ad2` may still have the error: `FileNotFoundError: File not found: "data"`. Therefore, in this PR, I still keep `torch==1.10.2` in order to make the notebook runnable. A further modify of this notebook is still necessary in the future.

Except for fixing the error above mentioned, this PR also changes the `num_workers` for `dataloader` and add the corresponding descriptions. Without the changes, there may have some warning messages during training, since the default `num_workers=0` is not optimized.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
