### PR TITLE
Update tutorials for 0.8.1

### DIFF
--- a/3d_segmentation/unet_segmentation_3d_ignite.ipynb
+++ b/3d_segmentation/unet_segmentation_3d_ignite.ipynb
@@ -332,7 +332,7 @@
     "post_pred = Compose(\n",
     "    [EnsureType(), Activations(sigmoid=True), AsDiscrete(threshold=0.5)]\n",
     ")\n",
-    "post_label = Compose([EnsureType(), AsDiscrete(threshold_values=True)])\n",
+    "post_label = Compose([EnsureType(), AsDiscrete(threshold=0.5)])\n",
     "# Ignite evaluator expects batch=(img, seg) and\n",
     "# returns output=(y_pred, y) at every iteration,\n",
     "# user can add output_transform to return other values\n",

--- a/acceleration/threadbuffer_performance.ipynb
+++ b/acceleration/threadbuffer_performance.ipynb
@@ -133,7 +133,7 @@
    "outputs": [],
    "source": [
     "device = torch.device(\"cuda:0\")\n",
-    "net = UNet(2, 1, 1, (8, 16, 32), (2, 2, 2), num_res_units=2).to(device)\n",
+    "net = UNet(2, 1, 1, (8, 16, 32), (2, 2), num_res_units=2).to(device)\n",
     "loss_function = Dice(sigmoid=True)\n",
     "optimizer = torch.optim.Adam(net.parameters(), 1e-5)\n",
     "max_epochs = 10"
@@ -251,7 +251,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -265,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/modules/interpretability/cats_and_dogs.ipynb
+++ b/modules/interpretability/cats_and_dogs.ipynb
@@ -21,6 +21,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install -q ipywidgets==7.6\n",
+    "\n",
     "from glob import glob\n",
     "import os\n",
     "from enum import Enum\n",
@@ -51,9 +53,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2553f762",
+   "metadata": {},
+   "source": [
+    "If you download the dataset from the abovementioned link, please set the `directory` to the path to `PetImages/`. For example:\n",
+    "\n",
+    "```\n",
+    "directory = \"/root_dir/kagglecatsanddogs_3367a/PetImages/\"\n",
+    "```\n",
+    "\n",
+    "and comment the following cell."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "5e7e5a28",
+   "execution_count": null,
+   "id": "cad0eb4f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,7 +455,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -453,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/multimodal/openi_multilabel_classification_transchex/transchex_openi_multilabel_classification.ipynb
+++ b/multimodal/openi_multilabel_classification_transchex/transchex_openi_multilabel_classification.ipynb
@@ -37,7 +37,7 @@
    "outputs": [],
    "source": [
     "!pip install -q \"monai[transformers, pandas]\"\n",
-    "!pip install -q scikit-learn==0.20.3\n",
+    "!pip install -q scikit-learn==1.0.2\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib\n",
     "%matplotlib inline"
    ]
@@ -62,7 +62,7 @@
     "import matplotlib.pyplot as plt\n",
     "from PIL import Image\n",
     "from torchvision import transforms\n",
-    "from sklearn.metrics.ranking import roc_auc_score\n",
+    "from sklearn.metrics import roc_auc_score\n",
     "from monai.optimizers.lr_scheduler import WarmupCosineSchedule\n",
     "from monai.networks.nets import Transchex\n",
     "from monai.config import print_config\n",
@@ -571,7 +571,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -585,7 +585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #565 .

### Description
This PR fixes some issues in some tutorials for monai==0.8.1.

For `unet_segmentation_3d_ignite.ipynb`, the api needs to be updated.
For `threadbuffer_performance.ipynb`, the length of `strides` argument is not correct (has one extra value which will not be used).
For the multi-modal tutorial, `scikit-learn==0.20.3` is not compatible with python 3.8, it needs to be replaced with v 1.0.2 to solve the error.
For `cats_and_dogs.ipynb`, I added some doc-strings to explain about how to set the `directory`, and added the install of `ipywidgets` to prevent a related error when download the pretrained weights.


However, there are still some tutorials that are not covered or have issues:

1. `pathology/` (need @drbeh for help to check)
2. `self_supervised_pretraining/` (everything is good except the uploaded pretrained weights, see #575 )
3. `performance_profilling/` (also shown in https://github.com/Project-MONAI/tutorials/issues/453, @dongyang0122 helped to figure out that using `num_workers=0` can avoid the issue, however, I'm not sure if it is enough. May need some time to find the root cause.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
