### PR TITLE
fixes 3849 zipped grid patch dataset

### DIFF
--- a/modules/nifti_read_example.ipynb
+++ b/modules/nifti_read_example.ipynb
@@ -47,26 +47,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MONAI version: 0.6.0rc1+23.gc6793fd0\n",
-      "Numpy version: 1.20.3\n",
-      "Pytorch version: 1.9.0a0+c3d40fd\n",
-      "MONAI flags: HAS_EXT = True, USE_COMPILED = False\n",
-      "MONAI rev id: c6793fd0f316a448778d0047664aaf8c1895fe1c\n",
+      "MONAI version: 0.8.1\n",
+      "Numpy version: 1.21.5\n",
+      "Pytorch version: 1.10.2\n",
+      "MONAI flags: HAS_EXT = False, USE_COMPILED = False\n",
+      "MONAI rev id: 71ff399a3ea07aef667b23653620a290364095b1\n",
       "\n",
       "Optional dependencies:\n",
-      "Pytorch Ignite version: 0.4.5\n",
+      "Pytorch Ignite version: 0.4.8\n",
       "Nibabel version: 3.2.1\n",
-      "scikit-image version: 0.15.0\n",
-      "Pillow version: 7.0.0\n",
-      "Tensorboard version: 2.5.0\n",
-      "gdown version: 3.13.0\n",
-      "TorchVision version: 0.10.0a0\n",
-      "ITK version: 5.1.2\n",
-      "tqdm version: 4.53.0\n",
-      "lmdb version: 1.2.1\n",
-      "psutil version: 5.8.0\n",
-      "pandas version: 1.1.4\n",
-      "einops version: 0.3.0\n",
+      "scikit-image version: 0.19.1\n",
+      "Pillow version: 9.0.0\n",
+      "Tensorboard version: 2.8.0\n",
+      "gdown version: 4.2.0\n",
+      "TorchVision version: 0.11.3\n",
+      "tqdm version: 4.62.3\n",
+      "lmdb version: 1.3.0\n",
+      "psutil version: 5.9.0\n",
+      "pandas version: 1.1.5\n",
+      "einops version: 0.4.0\n",
+      "transformers version: 4.16.1\n",
+      "mlflow version: 1.23.1\n",
       "\n",
       "For details about installing the optional dependencies, please visit:\n",
       "    https://docs.monai.io/en/latest/installation.html#installing-the-recommended-dependencies\n",
@@ -124,19 +125,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/tmp/tmp3y4h4i5o\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "directory = os.environ.get(\"MONAI_DATA_DIRECTORY\")\n",
     "root_dir = tempfile.mkdtemp() if directory is None else directory\n",
@@ -224,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively create a data loader which yields patches in regular grid order from loaded images:"
+    "Alternatively create a data loader which yields patches in regular grid order from loaded images (Note that `GridPatchDataset(..., with_coordinates=False)` is used to ignore additional output from the input `patch_iter`):"
    ]
   },
   {
@@ -238,8 +231,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "image shapes: torch.Size([3, 1, 64, 64, 64]) torch.Size([3, 1, 64, 64, 64])\n",
-      "coordinates shapes: torch.Size([3, 4, 2]) torch.Size([3, 4, 2])\n"
+      "image shapes: torch.Size([10, 1, 64, 64, 64]) torch.Size([10, 1, 64, 64, 64])\n"
      ]
     }
    ],
@@ -254,17 +246,19 @@
     "\n",
     "\n",
     "def img_seg_iter(x):\n",
-    "    return (zip(patch_iter(x[0]), patch_iter(x[1])),)\n",
+    "    for im, seg in zip(patch_iter(x[0]), patch_iter(x[1])):\n",
+    "        # uncomment this to confirm the coordinates\n",
+    "        # print(\"coord img:\", im[1].flatten(), \"coord seg:\", seg[1].flatten())\n",
+    "        yield ((im[0], seg[0]),)\n",
     "\n",
     "\n",
     "ds = GridPatchDataset(ds, img_seg_iter, with_coordinates=False)\n",
     "\n",
     "loader = torch.utils.data.DataLoader(\n",
-    "    ds, batch_size=10, num_workers=2, pin_memory=torch.cuda.is_available()\n",
+    "    ds, batch_size=10, num_workers=0, pin_memory=torch.cuda.is_available()\n",
     ")\n",
     "im, seg = first(loader)\n",
-    "print(\"image shapes:\", im[0].shape, seg[0].shape)\n",
-    "print(\"coordinates shapes:\", im[1].shape, seg[1].shape)"
+    "print(\"image shapes:\", im.shape, seg.shape)"
    ]
   },
   {
@@ -303,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes https://github.com/Project-MONAI/MONAI/issues/3849

### Description
the zip of two generators should be 

```py
def img_seg_iter(x):
    for im, seg in zip(patch_iter(x[0]), patch_iter(x[1])):
        yield ((im[0], seg[0]),)
```

instead of
```py
def img_seg_iter(x):
    return (zip(patch_iter(x[0]), patch_iter(x[1])),)
```

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
