### PR TITLE
652 Enhance `get_kernels_strides` of DynUNet pipeline

### DIFF
--- a/modules/dynunet_pipeline/create_network.py
+++ b/modules/dynunet_pipeline/create_network.py
@@ -32,7 +32,7 @@ def get_kernels_strides(task_id):
         for idx, (i, j) in enumerate(zip(sizes, stride)):
             if i % j != 0:
                 raise ValueError(
-                    f"patch size error, please try to modify the size {input_size[idx]} in dimension {idx}."
+                    f"patch size error, please try to modify the size {input_size[idx]} in the spatial dimension {idx}."
                 )
         sizes = [i / j for i, j in zip(sizes, stride)]
         spacings = [i * j for i, j in zip(spacings, stride)]

--- a/modules/dynunet_pipeline/create_network.py
+++ b/modules/dynunet_pipeline/create_network.py
@@ -7,22 +7,38 @@ from task_params import deep_supr_num, patch_size, spacing
 
 
 def get_kernels_strides(task_id):
-    sizes, spacings = patch_size[task_id], spacing[task_id]
-    strides, kernels = [], []
+    """
+    This function is only used for decathlon datasets with the provided patch sizes.
+    When refering this method for other tasks, please ensure that the patch size for each spatial dimension should
+    be divisible by the product of all strides in the corresponding dimension.
+    In addition, the minimal spatial size should have at least one dimension that has twice the size of
+    the product of all strides. For patch sizes that cannot find suitable strides, an error will be raised.
 
+    """
+    sizes, spacings = patch_size[task_id], spacing[task_id]
+    input_size = sizes
+    strides, kernels = [], []
+    min_patch_size = [1, 1, 1] * len(sizes)
     while True:
         spacing_ratio = [sp / min(spacings) for sp in spacings]
         stride = [
             2 if ratio <= 2 and size >= 8 else 1
             for (ratio, size) in zip(spacing_ratio, sizes)
         ]
+        min_patch_size = [i * j for i, j in zip(min_patch_size, stride)]
         kernel = [3 if ratio <= 2 else 1 for ratio in spacing_ratio]
         if all(s == 1 for s in stride):
             break
+        for idx, (i, j) in enumerate(zip(sizes, stride)):
+            if i % j != 0:
+                raise ValueError(
+                    f"patch size error, please try to modify the size {input_size[idx]} in dimension {idx}."
+                )
         sizes = [i / j for i, j in zip(sizes, stride)]
         spacings = [i * j for i, j in zip(spacings, stride)]
         kernels.append(kernel)
         strides.append(stride)
+
     strides.insert(0, len(spacings) * [1])
     kernels.append(len(spacings) * [3])
     return kernels, strides


### PR DESCRIPTION
Fixes #653.

### Description
Add some doc-strings to describe the requirements of the input size for DynUNet, and for sizes that cannot find suitable strides, an error will be raised. This change is helpful for users that need to use this function for other tasks.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
