### PR TITLE
Fix typo in the bundle example

### DIFF
--- a/modules/bundles/spleen_segmentation/configs/train.json
+++ b/modules/bundles/spleen_segmentation/configs/train.json
@@ -7,7 +7,7 @@
     "determinism": "$monai.utils.set_determinism(seed=123)",
     "cudnn_opt": "$setattr(torch.backends.cudnn, 'benchmark', True)",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
-    "ckpt_path": "/workspace/data/tutorials/modules/bundles/spleen_segmentation/models/model.pt",
+    "ckpt_dir": "/workspace/data/tutorials/modules/bundles/spleen_segmentation/models",
     "dataset_dir": "/workspace/data/Task09_Spleen",
     "images": "$list(sorted(glob.glob(@dataset_dir + '/imagesTr/*.nii.gz')))",
     "labels": "$list(sorted(glob.glob(@dataset_dir + '/labelsTr/*.nii.gz')))",
@@ -201,9 +201,10 @@
             },
             {
                 "_target_": "CheckpointSaver",
-                "save_dir": "@ckpt_path",
+                "save_dir": "@ckpt_dir",
                 "save_dict": {"model": "@network"},
-                "save_key_metric": true
+                "save_key_metric": true,
+                "key_metric_filename": "model.pt"
             }
         ],
         "key_metric": {

--- a/modules/bundles/spleen_segmentation/docs/README.md
+++ b/modules/bundles/spleen_segmentation/docs/README.md
@@ -50,7 +50,7 @@ python -m monai.bundle verify_net_in_out network_def --meta_file configs/metadat
 Export checkpoint to TorchScript file:
 
 ```
-python -m monai.bundle export network_def --filepath models/model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json
+python -m monai.bundle ckpt_export network_def --filepath models/model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
 # Disclaimer


### PR DESCRIPTION
### Description
This PR fixed several typo in the bundle example.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
