### PR TITLE
infoANDinference has not `max_epochs`

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -38,6 +38,7 @@ doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" tcia_csv_processing
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" transform_visualization.ipynb)
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" 2d_inference_3d_volume.ipynb)
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" resample_benchmark.ipynb)
+doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" infoANDinference.ipynb)
 
 # output formatting
 separator=""


### PR DESCRIPTION
Fixes # .

### Description
A few sentences describing the changes proposed in this pull request.

### Status
**Ready/Work in progress/Hold**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Notebook runs automatically `./runner [-p <regex_pattern>]`
