### PR TITLE
733 Fix bundle metadata errors

### DIFF
--- a/modules/bundle/spleen_segmentation/configs/metadata.json
+++ b/modules/bundle/spleen_segmentation/configs/metadata.json
@@ -16,7 +16,7 @@
     "authors": "MONAI team",
     "copyright": "Copyright (c) MONAI Consortium",
     "data_source": "Task09_Spleen.tar from http://medicaldecathlon.com/",
-    "data_type": "dicom",
+    "data_type": "nibabel",
     "image_classes": "single channel data, intensity scaled to [0, 1]",
     "label_classes": "single channel data, 1 is spleen, 0 is everything else",
     "pred_classes": "2 channels OneHot data, channel 1 is spleen, channel 0 is background",
@@ -32,19 +32,20 @@
         "inputs": {
             "image": {
                 "type": "image",
-                "format": "magnitude",
+                "format": "hounsfield",
+                "modality": "CT",
                 "num_channels": 1,
                 "spatial_shape": [
-                    160,
-                    160,
-                    160
+                    96,
+                    96,
+                    96
                 ],
                 "dtype": "float32",
                 "value_range": [
                     0,
                     1
                 ],
-                "is_patch_data": false,
+                "is_patch_data": true,
                 "channel_def": {
                     "0": "image"
                 }
@@ -53,19 +54,20 @@
         "outputs": {
             "pred": {
                 "type": "image",
-                "format": "segmentation",
+                "format": "hounsfield",
+                "modality": "CT",
                 "num_channels": 2,
                 "spatial_shape": [
-                    160,
-                    160,
-                    160
+                    96,
+                    96,
+                    96
                 ],
                 "dtype": "float32",
                 "value_range": [
                     0,
                     1
                 ],
-                "is_patch_data": false,
+                "is_patch_data": true,
                 "channel_def": {
                     "0": "background",
                     "1": "spleen"


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #733 .

### Description
This PR is used to modify the false descriptions in `metadata.json` of `spleen_segmentation` bundle.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
