### PR TITLE
Revert the modifications of outputs in "fix bundle metadata errors (#734)"

### DIFF
--- a/modules/bundle/spleen_segmentation/configs/metadata.json
+++ b/modules/bundle/spleen_segmentation/configs/metadata.json
@@ -16,7 +16,7 @@
     "authors": "MONAI team",
     "copyright": "Copyright (c) MONAI Consortium",
     "data_source": "Task09_Spleen.tar from http://medicaldecathlon.com/",
-    "data_type": "nibabel",
+    "data_type": "dicom",
     "image_classes": "single channel data, intensity scaled to [0, 1]",
     "label_classes": "single channel data, 1 is spleen, 0 is everything else",
     "pred_classes": "2 channels OneHot data, channel 1 is spleen, channel 0 is background",
@@ -32,20 +32,19 @@
         "inputs": {
             "image": {
                 "type": "image",
-                "format": "hounsfield",
-                "modality": "CT",
+                "format": "magnitude",
                 "num_channels": 1,
                 "spatial_shape": [
-                    96,
-                    96,
-                    96
+                    160,
+                    160,
+                    160
                 ],
                 "dtype": "float32",
                 "value_range": [
                     0,
                     1
                 ],
-                "is_patch_data": true,
+                "is_patch_data": false,
                 "channel_def": {
                     "0": "image"
                 }
@@ -54,20 +53,19 @@
         "outputs": {
             "pred": {
                 "type": "image",
-                "format": "hounsfield",
-                "modality": "CT",
+                "format": "segmentation",
                 "num_channels": 2,
                 "spatial_shape": [
-                    96,
-                    96,
-                    96
+                    160,
+                    160,
+                    160
                 ],
                 "dtype": "float32",
                 "value_range": [
                     0,
                     1
                 ],
-                "is_patch_data": true,
+                "is_patch_data": false,
                 "channel_def": {
                     "0": "background",
                     "1": "spleen"

--- a/modules/bundle/spleen_segmentation/configs/metadata.json
+++ b/modules/bundle/spleen_segmentation/configs/metadata.json
@@ -33,7 +33,7 @@
             "image": {
                 "type": "image",
                 "format": "hounsfield",
-                "modility": "CT",
+                "modality": "CT",
                 "num_channels": 1,
                 "spatial_shape": [
                     96,

--- a/modules/bundle/spleen_segmentation/configs/metadata.json
+++ b/modules/bundle/spleen_segmentation/configs/metadata.json
@@ -16,7 +16,7 @@
     "authors": "MONAI team",
     "copyright": "Copyright (c) MONAI Consortium",
     "data_source": "Task09_Spleen.tar from http://medicaldecathlon.com/",
-    "data_type": "dicom",
+    "data_type": "nibabel",
     "image_classes": "single channel data, intensity scaled to [0, 1]",
     "label_classes": "single channel data, 1 is spleen, 0 is everything else",
     "pred_classes": "2 channels OneHot data, channel 1 is spleen, channel 0 is background",
@@ -32,19 +32,20 @@
         "inputs": {
             "image": {
                 "type": "image",
-                "format": "magnitude",
+                "format": "hounsfield",
+                "modility": "CT",
                 "num_channels": 1,
                 "spatial_shape": [
-                    160,
-                    160,
-                    160
+                    96,
+                    96,
+                    96
                 ],
                 "dtype": "float32",
                 "value_range": [
                     0,
                     1
                 ],
-                "is_patch_data": false,
+                "is_patch_data": true,
                 "channel_def": {
                     "0": "image"
                 }
@@ -56,16 +57,16 @@
                 "format": "segmentation",
                 "num_channels": 2,
                 "spatial_shape": [
-                    160,
-                    160,
-                    160
+                    96,
+                    96,
+                    96
                 ],
                 "dtype": "float32",
                 "value_range": [
                     0,
                     1
                 ],
-                "is_patch_data": false,
+                "is_patch_data": true,
                 "channel_def": {
                     "0": "background",
                     "1": "spleen"


### PR DESCRIPTION
Reverts Project-MONAI/tutorials#734

The format of `outputs` should be `segmentation`, and should not have `modility`.