### PR TITLE
752 Add ignite into bundle metadata

### DIFF
--- a/modules/bundle/spleen_segmentation/configs/metadata.json
+++ b/modules/bundle/spleen_segmentation/configs/metadata.json
@@ -9,7 +9,8 @@
     "pytorch_version": "1.10.0",
     "numpy_version": "1.21.2",
     "optional_packages_version": {
-        "nibabel": "3.2.1"
+        "nibabel": "3.2.1",
+        "pytorch-ignite": "0.4.8"
     },
     "task": "Decathlon spleen segmentation",
     "description": "A pre-trained model for volumetric (3D) segmentation of the spleen from CT image",


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #752 .

### Description
This PR is used to add ignite as an optional package into the spleen bundle's `metadata.json`.

### Status
**Ready**

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
