### PR TITLE
NuClick Needs AsDiscreted transform input argument fix for MONAI v1.0

### DIFF
--- a/nuclick/nuclick_training_notebook.ipynb
+++ b/nuclick/nuclick_training_notebook.ipynb
@@ -2278,7 +2278,7 @@
     "\n",
     "train_post_transforms = Compose([\n",
     "    Activationsd(keys=\"pred\", sigmoid=True),\n",
-    "    AsDiscreted(keys=\"pred\", threshold_values=True, logit_thresh=0.5),\n",
+    "    AsDiscreted(keys=\"pred\", threshold=0.5),\n",
     "]\n",
     ")\n",
     "\n",
@@ -2507,9 +2507,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nuclick_tutorial",
+   "display_name": "py38_monai_v1_tutorial_test",
    "language": "python",
-   "name": "nuclick_tutorial"
+   "name": "py38_monai_v1_tutorial_test"
   },
   "language_info": {
    "codemirror_mode": {

--- a/self_supervised_pretraining/ssl_script_train.py
+++ b/self_supervised_pretraining/ssl_script_train.py
@@ -27,9 +27,9 @@ from monai.transforms import (
 def main():
 
     #TODO Defining file paths & output directory path
-    json_Path = os.path.normpath('/scratch/data_2021/tcia_covid19/dataset_split_debug.json')
-    data_Root = os.path.normpath('/scratch/data_2021/tcia_covid19')
-    logdir_path = os.path.normpath('/home/vishwesh/monai_tutorial_testing/issue_467')
+    json_Path = os.path.normpath('/to/be/defined/by/user/')
+    data_Root = os.path.normpath('/to/be/defined/by/user/')
+    logdir_path = os.path.normpath('/to/be/defined/by/user/')
 
     if os.path.exists(logdir_path)==False:
         os.mkdir(logdir_path)


### PR DESCRIPTION
Input arguments for transform "AsDiscreted" that were probably modified for upcoming MONAI v1.0 release were modified, hence they needed to be updated in the NuClick Tutorial

Other minor fixes in SSL tutorial path, no major changes.

Signed-off-by: Vishwesh Nath <vnath@nvidia.com>

