### PR TITLE
330 Update Tutorial README with Triton

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ The examples show how to train federated learning models based on [OpenFL](https
 #### [Substra](./federated_learning/substra)
 The example show how to execute the 3d segmentation torch tutorial on a federated learning platform, Substra.
 
+#### [Triton](./deployment/Triton/)
+This is example walks through using a Triton Server and Python client using MONAI on the MedNIST classification problem. The demo is self contained and the Readme explains how to use Triton "backends" to inject the MONAI code into the server.  [See Triton Inference Server/python_backend documentation](https://github.com/triton-inference-server/python_backend#usage)
+
 **Digital Pathology**
 #### [Whole Slide Tumor Detection](./pathology/tumor_detection)
 The example show how to train and evaluate a tumor detection model (based on patch classification) on whole-slide histopathology images.


### PR DESCRIPTION
Signed-off-by: Sidney L. Bryson <sbryson@nvidia.com>

Fixes # .
330
### Description
The Triton Demo description is missing from the Tutorials description. Adding a paragraph in Alphabetical order to the list of descriptions.
### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
