### PR TITLE
update to use cachedataset in `modules/transforms_metatensor.ipynb`

### DIFF
--- a/modules/transforms_metatensor.ipynb
+++ b/modules/transforms_metatensor.ipynb
@@ -678,17 +678,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "id": "0KW-sSopogSd"
-   },
-   "outputs": [],
-   "source": [
-    "!rm -rf cache/*.pt"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "Doa85XTgK0SW"

--- a/modules/transforms_metatensor.ipynb
+++ b/modules/transforms_metatensor.ipynb
@@ -320,7 +320,7 @@
    "source": [
     "monai.utils.set_determinism(2022)\n",
     "\n",
-    "dataset = monai.data.PersistentDataset(train_files, t, cache_dir=\"./cache\", hash_transform=monai.data.json_hashing)\n",
+    "dataset = monai.data.CacheDataset(train_files, t, cache_rate=1.0, copy_cache=False)\n",
     "batch_loader = monai.data.ThreadDataLoader(dataset, num_workers=0, batch_size=2, shuffle=True)\n",
     "\n",
     "batch = monai.utils.first(batch_loader)\n",

--- a/runner.sh
+++ b/runner.sh
@@ -43,6 +43,7 @@ doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" dice_loss_metric_no
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" 2d_slices_from_3d_sampling.ipynb)
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" data_analyzer.ipynb)
 doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" data_analyzer_byoc.ipynb)
+doesnt_contain_max_epochs=("${doesnt_contain_max_epochs[@]}" transforms_metatensor.ipynb)
 
 # output formatting
 separator=""


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>


### Description
revise to use the cachedataset, so that the cache can be on gpu.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
