### PR TITLE
Fixed minor typos in tutorial "auto3dseg"

### DIFF
--- a/auto3dseg/docs/run_with_minimal_input.md
+++ b/auto3dseg/docs/run_with_minimal_input.md
@@ -158,7 +158,7 @@ stats_summary:
 ...
 ```
 
-2."algorithm_templates" are the [algorithm templates]("../docs/algorithm_generation.md#algorithm-templates") that used to generate actual algorithm bundle folders with information from data statistics.
+2."algorithm_templates" are the [algorithm templates](../docs/algorithm_generation.md#algorithm-templates) that used to generate actual algorithm bundle folders with information from data statistics.
 
 3."dints_x", "segresnet_x", "segresnet2d_x", "swinunetr_x" are automically generated 5-fold MONAI bundle based on [established networks and well-tuned training recipes](../docs/algorithm_generation.md#algorithms). They are self-contained folder, which can be used for model training, inference, validation via executing commands in the README document of each bundle folder. More information can be referred via this [link](https://docs.monai.io/en/latest/mb_specification.html). And "model_foldx" is where checkpoints after training are saved together with training history and tensorboard event files.
 


### PR DESCRIPTION
Fixed minor typos in tutorial "auto3dseg".

### Description
A few sentences describing the changes proposed in this pull request.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
