### PR TITLE
1056 extract_levels in paired lung ct

### DIFF
--- a/3d_registration/paired_lung_ct.ipynb
+++ b/3d_registration/paired_lung_ct.ipynb
@@ -539,7 +539,7 @@
     "    in_channels=2,\n",
     "    out_channels=3,\n",
     "    num_channel_initial=32,\n",
-    "    extract_levels=[0, 1, 2, 3],\n",
+    "    extract_levels=[3],\n",
     "    out_activation=None,\n",
     "    out_kernel_initializer=\"zeros\").to(device)\n",
     "warp_layer = Warp().to(device)\n",


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

workaround as mentioned in #1056


### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Notebook runs automatically `./runner [-p <regex_pattern>]`
