### PR TITLE
Drop check of monai.utils.get_torch_version_tuple() >= (1, 6)

### DIFF
--- a/acceleration/distributed_training/unet_evaluation_workflows.py
+++ b/acceleration/distributed_training/unet_evaluation_workflows.py
@@ -173,8 +173,7 @@ def evaluate(args):
         },
         additional_metrics={"val_acc": Accuracy(output_transform=from_engine(["pred", "label"]), device=device)},
         val_handlers=val_handlers,
-        # if no FP16 support in GPU or PyTorch version < 1.6, will not enable AMP evaluation
-        amp=True if monai.utils.get_torch_version_tuple() >= (1, 6) else False,
+        amp=True,
     )
     evaluator.run()
     dist.destroy_process_group()

--- a/acceleration/distributed_training/unet_training_workflows.py
+++ b/acceleration/distributed_training/unet_training_workflows.py
@@ -177,8 +177,7 @@ def train(args):
         optimizer=opt,
         loss_function=loss,
         inferer=SimpleInferer(),
-        # if no FP16 support in GPU or PyTorch version < 1.6, will not enable AMP evaluation
-        amp=True if monai.utils.get_torch_version_tuple() >= (1, 6) else False,
+        amp=True,
         postprocessing=train_post_transforms,
         key_train_metric={"train_acc": Accuracy(output_transform=from_engine(["pred", "label"]), device=device)},
         train_handlers=train_handlers,

--- a/modules/engines/unet_evaluation_dict.py
+++ b/modules/engines/unet_evaluation_dict.py
@@ -112,8 +112,7 @@ def main(tempdir):
         },
         additional_metrics={"val_acc": Accuracy(output_transform=from_engine(["pred", "label"]))},
         val_handlers=val_handlers,
-        # if no FP16 support in GPU or PyTorch version < 1.6, will not enable AMP evaluation
-        amp=True if monai.utils.get_torch_version_tuple() >= (1, 6) else False,
+        amp=True,
     )
     evaluator.run()
 

--- a/modules/engines/unet_training_dict.py
+++ b/modules/engines/unet_training_dict.py
@@ -147,8 +147,7 @@ def main(tempdir):
         },
         additional_metrics={"val_acc": Accuracy(output_transform=from_engine(["pred", "label"]))},
         val_handlers=val_handlers,
-        # if no FP16 support in GPU or PyTorch version < 1.6, will not enable AMP evaluation
-        amp=True if monai.utils.get_torch_version_tuple() >= (1, 6) else False,
+        amp=True,
     )
 
     train_post_transforms = Compose(
@@ -182,7 +181,7 @@ def main(tempdir):
         key_train_metric={"train_acc": Accuracy(output_transform=from_engine(["pred", "label"]))},
         train_handlers=train_handlers,
         # if no FP16 support in GPU or PyTorch version < 1.6, will not enable AMP training
-        amp=True if monai.utils.get_torch_version_tuple() >= (1, 6) else False,
+        amp=True,
     )
     # set initialized trainer for "early stop" handlers
     val_handlers[0].set_trainer(trainer=trainer)

--- a/pathology/tumor_detection/ignite/camelyon_train_evaluate.py
+++ b/pathology/tumor_detection/ignite/camelyon_train_evaluate.py
@@ -184,12 +184,6 @@ def train(cfg):
     else:
         optimizer = SGD(model.parameters(), lr=cfg["lr"], momentum=0.9)
 
-    # AMP scaler
-    if cfg["amp"]:
-        cfg["amp"] = True if monai.utils.get_torch_version_tuple() >= (1, 6) else False
-    else:
-        cfg["amp"] = False
-
     scheduler = lr_scheduler.CosineAnnealingLR(optimizer, T_max=cfg["n_epochs"])
 
     # --------------------------------------------

--- a/pathology/tumor_detection/ignite/camelyon_train_evaluate_nvtx_profiling.py
+++ b/pathology/tumor_detection/ignite/camelyon_train_evaluate_nvtx_profiling.py
@@ -187,12 +187,6 @@ def train(cfg):
     else:
         optimizer = SGD(model.parameters(), lr=cfg["lr"], momentum=0.9)
 
-    # AMP scaler
-    if cfg["amp"]:
-        cfg["amp"] = True if monai.utils.get_torch_version_tuple() >= (1, 6) else False
-    else:
-        cfg["amp"] = False
-
     scheduler = lr_scheduler.CosineAnnealingLR(optimizer, T_max=cfg["n_epochs"])
 
     # --------------------------------------------

--- a/pathology/tumor_detection/torch/camelyon_train_evaluate_pytorch_gpu.py
+++ b/pathology/tumor_detection/torch/camelyon_train_evaluate_pytorch_gpu.py
@@ -375,7 +375,6 @@ def main(cfg):
         optimizer = SGD(model.parameters(), lr=cfg["lr"], momentum=0.9)
 
     # AMP scaler
-    cfg["amp"] = cfg["amp"] and monai.utils.get_torch_version_tuple() >= (1, 6)
     if cfg["amp"] is True:
         scaler = GradScaler()
     else:

--- a/performance_profiling/pathology/train_evaluate_nvtx.py
+++ b/performance_profiling/pathology/train_evaluate_nvtx.py
@@ -382,7 +382,6 @@ def main(cfg):
         optimizer = SGD(model.parameters(), lr=cfg["lr"], momentum=0.9)
 
     # AMP scaler
-    cfg["amp"] = cfg["amp"] and monai.utils.get_torch_version_tuple() >= (1, 6)
     if cfg["amp"] is True:
         scaler = GradScaler()
     else:


### PR DESCRIPTION
Fixes #509

### Description
Drop check of monai.utils.get_torch_version_tuple() >= (1, 6) because the core codebase now requires at least torch 1.6. See also [here](https://github.com/Project-MONAI/MONAI/pull/3353)

### Checks
- [x] Notebook runs automatically `./runner [-p <regex_pattern>]`
