### PR TITLE
Fix early termination of integration test

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -339,7 +339,7 @@ for file in "${files[@]}"; do
 
 		if [ $skipRun = true ]; then
 			echo "Skipping"
-			break
+			continue
 		fi
 
 		echo Running notebook...


### PR DESCRIPTION
Signed-off-by: Mingxin Zheng <18563433+mingxin-zheng@users.noreply.github.com>

Fixes #1141 .

### Description
break -> continue

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [x] Remove private info such as user name and private key from the notebook and script files.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [x] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
