### PR TITLE
1155 workaround and verbose option

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -174,6 +174,7 @@ do
         ;;
         --verbose)
             papermill_opt=" --log-output --log-level DEBUG "
+        ;;
         --no-checks)
             doChecks=false
         ;;

--- a/runner.sh
+++ b/runner.sh
@@ -83,7 +83,7 @@ skip_run_papermill=("${skip_run_papermill[@]}" .*monailabel_pancreas_tumor_segme
 skip_run_papermill=("${skip_run_papermill[@]}" .*monailabel_endoscopy_cvat_tooltracking*)
 skip_run_papermill=("${skip_run_papermill[@]}" .*monailabel_pathology_nuclei_segmentation_QuPath*)
 skip_run_papermill=("${skip_run_papermill[@]}" .*monailabel_radiology_spleen_segmentation_OHIF*)
-skip_run_papermill=("${skip_run_papermill[@]}" .*transform_visualization.ipynb*)  # https://github.com/Project-MONAI/tutorials/issues/1155
+skip_run_papermill=("${skip_run_papermill[@]}" .*transform_visualization*)  # https://github.com/Project-MONAI/tutorials/issues/1155
 
 # output formatting
 separator=""

--- a/runner.sh
+++ b/runner.sh
@@ -509,7 +509,9 @@ for file in "${files[@]}"; do
         done
 
         python -c 'import monai; monai.config.print_config()'
-        time out=$(echo "$notebook" | papermill "$papermill_opt" --progress-bar -k "$kernelspec")
+        cmd=$(echo "papermill ${papermill_opt} --progress-bar -k ${kernelspec}")
+        echo "$cmd"
+        time out=$(echo "$notebook" | eval "$cmd")
         success=$?
         if [[ ${success} -ne 0 || "$out" =~ "\"status\": \"failed\"" ]]; then
             test_fail ${success}

--- a/runner.sh
+++ b/runner.sh
@@ -107,6 +107,7 @@ doStandardizeCells=false
 autofix=false
 failfast=false
 pattern=""
+papermill_opt=""
 
 kernelspec="python3"
 
@@ -116,7 +117,7 @@ NB_OUTPUT_LINE_CAP=100
 
 function print_usage {
     echo "runner.sh [--no-run] [--no-checks] [--autofix] [-f/--failfast] [-p/--pattern <find pattern>] [-h/--help]"
-    echo            "[-v/--version]"
+    echo            "[-v/--version] [--verbose]"
     echo ""
     echo "MONAI tutorials testing utilities. When running the notebooks, we first search for variables, such as"
     echo "\"max_epochs\" and set them to 1 to reduce testing time."
@@ -132,6 +133,7 @@ function print_usage {
     echo "    -h, --help        : show this help message and exit"
     echo "    -t, --test        : shortcut to run a single notebook using pattern \`-and -wholename\`"
     echo "    -v, --version     : show MONAI and system version information and exit"
+    echo "    --verbose         : show papermill logs when testing the noteboobks"
     echo ""
     echo "Examples:"
     echo "./runner.sh                             # run full tests (${green}recommended before making pull requests${noColor})."
@@ -170,6 +172,8 @@ do
         --no-run)
             doRun=false
         ;;
+        --verbose)
+            papermill_opt=" --log-output --log-level DEBUG "
         --no-checks)
             doChecks=false
         ;;
@@ -504,7 +508,7 @@ for file in "${files[@]}"; do
         done
 
         python -c 'import monai; monai.config.print_config()'
-        time out=$(echo "$notebook" | papermill --progress-bar -k "$kernelspec")
+        time out=$(echo "$notebook" | papermill "$papermill_opt" --progress-bar -k "$kernelspec")
         success=$?
         if [[ ${success} -ne 0 || "$out" =~ "\"status\": \"failed\"" ]]; then
             test_fail ${success}

--- a/runner.sh
+++ b/runner.sh
@@ -83,6 +83,7 @@ skip_run_papermill=("${skip_run_papermill[@]}" .*monailabel_pancreas_tumor_segme
 skip_run_papermill=("${skip_run_papermill[@]}" .*monailabel_endoscopy_cvat_tooltracking*)
 skip_run_papermill=("${skip_run_papermill[@]}" .*monailabel_pathology_nuclei_segmentation_QuPath*)
 skip_run_papermill=("${skip_run_papermill[@]}" .*monailabel_radiology_spleen_segmentation_OHIF*)
+skip_run_papermill=("${skip_run_papermill[@]}" .*transform_visualization.ipynb*)  # https://github.com/Project-MONAI/tutorials/issues/1155
 
 # output formatting
 separator=""


### PR DESCRIPTION
- workaround for #1155
  - skip transform_visualization.ipynb
- adds `--verbose` for runner.sh

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [x] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
