### PR TITLE
1167 protobuf fix

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -157,13 +157,6 @@ function print_usage {
     echo "To choose an alternative python executable, set the environmental variable, \"MONAI_PY_EXE\"."
 }
 
-# FIXME: https://github.com/Project-MONAI/MONAI/issues/4354
-protobuf_major_version=$(${PY_EXE} -m pip list | grep '^protobuf ' | tr -s ' ' | cut -d' ' -f2 | cut -d'.' -f1)
-if [ "$protobuf_major_version" -ge "4" ]
-then
-    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
-fi
-
 function print_style_fail_msg() {
     echo "${red}Check failed!${noColor}"
 }
@@ -517,6 +510,16 @@ for file in "${files[@]}"; do
         done
 
         python -c 'import monai; monai.config.print_config()'
+
+        # FIXME: https://github.com/Project-MONAI/MONAI/issues/4354
+        protobuf_major_version=$(${PY_EXE} -m pip list | grep '^protobuf ' | tr -s ' ' | cut -d' ' -f2 | cut -d'.' -f1)
+        if [ "$protobuf_major_version" -ge "4" ]
+        then
+            export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+        else
+            export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=
+        fi
+
         cmd=$(echo "papermill ${papermill_opt} --progress-bar -k ${kernelspec}")
         echo "$cmd"
         time out=$(echo "$notebook" | eval "$cmd")


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #1167

the workaround should be applied per notebook, because each notebook may install a different set of deps.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
