### PR TITLE
1191 fixes deprecated args

### DIFF
--- a/deepgrow/ignite/inference.ipynb
+++ b/deepgrow/ignite/inference.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -32,7 +31,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -49,7 +47,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -461,7 +458,7 @@
     "    Spacingd(keys='image', pixdim=pixdim, mode='bilinear'),\n",
     "\n",
     "    AddGuidanceFromPointsd(ref_image='image', guidance='guidance', foreground='foreground', background='background',\n",
-    "                           dimensions=dimensions),\n",
+    "                           spatial_dims=dimensions),\n",
     "    Fetch2DSliced(keys='image', guidance='guidance'),\n",
     "    AddChanneld(keys='image'),\n",
     "\n",
@@ -655,7 +652,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -669,7 +666,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {

--- a/deepgrow/ignite/inference_3d.ipynb
+++ b/deepgrow/ignite/inference_3d.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -18,7 +17,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -35,7 +33,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -183,7 +180,7 @@
     "    AsChannelFirstd(keys='image'),\n",
     "    Spacingd(keys='image', pixdim=pixdim, mode='bilinear'),\n",
     "    AddGuidanceFromPointsd(ref_image='image', guidance='guidance', foreground='foreground', background='background',\n",
-    "                           dimensions=dimensions),\n",
+    "                           spatial_dims=dimensions),\n",
     "    AddChanneld(keys='image'),\n",
     "    SpatialCropGuidanced(keys='image', guidance='guidance', spatial_size=roi_size),\n",
     "    Resized(keys='image', spatial_size=model_size, mode='area'),\n",
@@ -333,7 +330,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -347,7 +344,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #1191

### Description
dimensions -> spatial_dims

see also
https://github.com/Project-MONAI/MONAI/pull/5901/files#diff-de1bb0722a11b59358d44127ab828343ddd49e2b0478ff9f9d07e96a6f91c5de

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
