### PR TITLE
1195 add missing flag in dynunet tutorial

### DIFF
--- a/modules/dynunet_pipeline/train.py
+++ b/modules/dynunet_pipeline/train.py
@@ -97,7 +97,8 @@ def validation(args):
                     "mean dice for label {} is {}".format(i + 1, results[:, i].mean())
                 )
 
-    dist.destroy_process_group()
+    if multi_gpu_flag:
+        dist.destroy_process_group()
 
 
 def train(args):
@@ -227,7 +228,8 @@ def train(args):
         trainer.logger.setLevel(logging.WARNING)
 
     trainer.run()
-    dist.destroy_process_group()
+    if multi_gpu_flag:
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #1195 .

### Description
This PR adds the missing `multi_gpu_flag` in the train script.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
