### PR TITLE
update the ssim function for the reconstruction tutorial

### DIFF
--- a/reconstruction/MRI_reconstruction/unet_demo/fastmri_ssim.py
+++ b/reconstruction/MRI_reconstruction/unet_demo/fastmri_ssim.py
@@ -26,4 +26,4 @@ def skimage_ssim(gt: ndarray, rec: ndarray) -> float:
         skimage SSIM score between gt and rec
     """
     # assumes 3D inputs
-    return compare_ssim(gt.transpose(1, 2, 0), rec.transpose(1, 2, 0), multichannel=True, data_range=gt.max())
+    return compare_ssim(gt.transpose(1, 2, 0), rec.transpose(1, 2, 0), channel_axis=2, data_range=gt.max())

--- a/reconstruction/MRI_reconstruction/varnet_demo/fastmri_ssim.py
+++ b/reconstruction/MRI_reconstruction/varnet_demo/fastmri_ssim.py
@@ -26,4 +26,4 @@ def skimage_ssim(gt: ndarray, rec: ndarray) -> float:
         skimage SSIM score between gt and rec
     """
     # assumes 3D inputs
-    return compare_ssim(gt.transpose(1, 2, 0), rec.transpose(1, 2, 0), multichannel=True, data_range=gt.max())
+    return compare_ssim(gt.transpose(1, 2, 0), rec.transpose(1, 2, 0), channel_axis=2, data_range=gt.max())


### PR DESCRIPTION
### Description
The [structural_similarity](https://scikit-image.org/docs/dev/api/skimage.metrics.html#skimage.metrics.structural_similarity) API has changed since `skimage` version `0.19` and the `skimage` in MONAI Toolkit1.1 is `0.20`. Therefore the ssim calculation function in the reconstruction tutorial will report a bug shown below. 

This PR tries to update the ssim calculation function to the newest API to fix this bug. @Can-Zhao Could you please help to double check this change to see if it compatible with all reconstruction functions. If there are any questions about the docker image and environment, please refer to @mingxin-zheng for help. 

![image](https://user-images.githubusercontent.com/107988372/230829511-ea2f8821-7680-4339-9405-8ea3aff12636.png)

Thanks,
Bin   

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
