### PR TITLE
Fix commented item in MONAI 101 tutorial

### DIFF
--- a/2d_classification/monai_101.ipynb
+++ b/2d_classification/monai_101.ipynb
@@ -64,11 +64,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MONAI version: 1.2.0rc4\n",
+      "MONAI version: 1.2.0rc4+2.g57c618cc\n",
       "Numpy version: 1.22.2\n",
       "Pytorch version: 1.14.0a0+410ce96\n",
       "MONAI flags: HAS_EXT = False, USE_COMPILED = False, USE_META_DICT = False\n",
-      "MONAI rev id: 1a55ba5423d04d2ef7ac19356ccabc4c7906f577\n",
+      "MONAI rev id: 57c618cc0be2c081bae4caec13cf326c66874605\n",
       "MONAI __file__: /workspace/monai/monai-in-dev/monai/__init__.py\n",
       "\n",
       "Optional dependencies:\n",
@@ -109,7 +109,7 @@
     "from monai.inferers import SimpleInferer\n",
     "from monai.networks import eval_mode\n",
     "from monai.networks.nets import densenet121\n",
-    "from monai.transforms import LoadImageD, EnsureChannelFirstD, ScaleIntensityD, ToTensorD, Compose\n",
+    "from monai.transforms import LoadImageD, EnsureChannelFirstD, ScaleIntensityD, Compose\n",
     "\n",
     "print_config()"
    ]
@@ -155,7 +155,7 @@
     "Medical images require specialized methods for I/O, preprocessing, and augmentation.\n",
     "They often follow specific formats, are handled with specific protocols, and the data arrays are often high-dimensional.\n",
     "\n",
-    "In this example, we will perform image loading, data format verification, intensity scaling, and conversion to Tensor with four `monai.transforms` listed below, and compose a pipeline ready to be used in next steps."
+    "In this example, we will perform image loading, data format verification, and intensity scaling with three `monai.transforms` listed below, and compose a pipeline ready to be used in next steps."
    ]
   },
   {
@@ -169,7 +169,6 @@
     "        LoadImageD(keys=\"image\", image_only=True),\n",
     "        EnsureChannelFirstD(keys=\"image\"),\n",
     "        ScaleIntensityD(keys=\"image\"),\n",
-    "        ToTensorD(keys=[\"image\", \"label\"]),\n",
     "    ]\n",
     ")"
    ]
@@ -202,16 +201,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-04-13 15:29:44,888 - INFO - Verified 'MedNIST.tar.gz', md5: 0bc7306e7427e00ad1c5526a6677552d.\n",
-      "2023-04-13 15:29:44,889 - INFO - File exists: /workspace/data/MedNIST.tar.gz, skipped downloading.\n",
-      "2023-04-13 15:29:44,889 - INFO - Non-empty folder exists in /workspace/data/MedNIST, skipped extracting.\n"
+      "2023-04-14 11:54:20,086 - INFO - Verified 'MedNIST.tar.gz', md5: 0bc7306e7427e00ad1c5526a6677552d.\n",
+      "2023-04-14 11:54:20,087 - INFO - File exists: /workspace/data/MedNIST.tar.gz, skipped downloading.\n",
+      "2023-04-14 11:54:20,087 - INFO - Non-empty folder exists in /workspace/data/MedNIST, skipped extracting.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Loading dataset: 100%|██████████| 47164/47164 [00:23<00:00, 2009.60it/s]\n"
+      "Loading dataset: 100%|██████████| 47164/47164 [00:18<00:00, 2579.81it/s]\n"
      ]
     }
    ],
@@ -278,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Fixes a comment for MONAI 101 tutorial.

https://github.com/Project-MONAI/tutorials/pull/1303#discussion_r1166713750

### Description
A few sentences describing the changes proposed in this pull request.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [x] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
