### PR TITLE
Update notebooks under pathology/nuclick folder

### DIFF
--- a/pathology/nuclick/nuclei_classification_training_notebook.ipynb
+++ b/pathology/nuclick/nuclei_classification_training_notebook.ipynb
@@ -17,6 +17,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -33,7 +34,7 @@
     "\n",
     "### Features in the tutorial:\n",
     "* Utilizes new transforms that were added/updated for v1.1 of MONAI.\n",
-    "* Data pre-processing functions, as typically pathology data is given as a whole slide, which cannot be directly used for training as it's too large in size, in particular check `split_concep_dataset`\n",
+    "* Data pre-processing functions, as typically pathology data is given as a whole slide, which cannot be directly used for training as it's too large in size, in particular check `consep_nuclei_dataset`\n",
     "* Uses the dataset: \n",
     "\n",
     "This model is trained using [DenseNet121](https://docs.monai.io/en/latest/networks.html#densenet121) over [ConSeP](https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet) dataset.  \n",
@@ -879,32 +880,33 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The results can be visualizaed by passing the logging_dir variable path to tensorboard. \n",
     "\n",
-    "For example: `tensorboard --logdir=workspace\\train_run_01`\n",
+    "For example: `tensorboard --logdir=workspace/train_run_01`\n",
     "\n",
     "\n",
     "## Scores\n",
     "This model achieves the following F1 score on the validation data provided as part of the dataset:\n",
     "\n",
-    "- Train F1 score = 0.96\n",
-    "- Validation F1 score = 0.85\n",
+    "- Train F1 score = 0.926\n",
+    "- Validation F1 score = 0.852\n",
     "\n",
     "\n",
     "\n",
     "## Training Performance\n",
     "A graph showing the training Loss and F1-score over 50 epochs.\n",
     "\n",
-    "![Train Loss](https://github.com/Project-MONAI/model-zoo/raw/dev/models/pathology_nuclei_classification/docs/images/train_loss.jpeg)\n",
-    "![Train F1](https://github.com/Project-MONAI/model-zoo/raw/dev/models/pathology_nuclei_classification/docs/images/train_f1.jpeg)\n",
+    "![Train Loss](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_train_loss_v3.png)\n",
+    "![Train F1](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_train_f1_v3.png)\n",
     "\n",
     "## Validation Performance\n",
     "A graph showing the validation F1-score over 50 epochs.\n",
     "\n",
-    "![Val F1](https://github.com/Project-MONAI/model-zoo/raw/dev/models/pathology_nuclei_classification/docs/images/val_f1.jpeg)\n",
+    "![Val F1](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_val_f1_v3.png)\n",
     "\n",
     "\n"
    ]

--- a/pathology/nuclick/nuclei_classification_training_notebook.ipynb
+++ b/pathology/nuclick/nuclei_classification_training_notebook.ipynb
@@ -880,7 +880,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -898,13 +897,13 @@
     "\n",
     "\n",
     "## Training Performance\n",
-    "A graph showing the training Loss and F1-score over 50 epochs.\n",
+    "A graph showing the training Loss and F1-score over 100 epochs.\n",
     "\n",
     "![Train Loss](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_train_loss_v3.png)\n",
     "![Train F1](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_train_f1_v3.png)\n",
     "\n",
     "## Validation Performance\n",
-    "A graph showing the validation F1-score over 50 epochs.\n",
+    "A graph showing the validation F1-score over 100 epochs.\n",
     "\n",
     "![Val F1](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_val_f1_v3.png)\n",
     "\n",


### PR DESCRIPTION
Fixes #1298.

### Description
- update figures' links in `nuclick_training_notebook.ipynb`
- update figures' link in `nuclei_classification_training_notebook.ipynb`
- use Unix-style path in tensorboard cmd 

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
