### PR TITLE
Remove file_slices from ensemble example because it fails when #GPU>2

### DIFF
--- a/auto3dseg/notebooks/auto_runner.ipynb
+++ b/auto3dseg/notebooks/auto_runner.ipynb
@@ -33,7 +33,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup environment"
+    "## Setup environment\n",
+    "\n",
+    "The **Auto3DSeg** modules support multiple GPU since MONAI 1.2.\n",
+    "The GPU devices are selected via setting the environment variable `CUDA_VISIBLE_DEVICES`.\n",
+    "For example, if the users need to select GPU 0 to run this notebook, please add the `%env CUDA_VISIBLE_DEVICES=0` in the next cell"
    ]
   },
   {
@@ -324,10 +328,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Customize the inference parameters by override the default values"
+    "## Customize the inference parameters by override the default values\n",
+    "\n",
+    "Check the [MONAI Auto3DSeg API Documentation](https://docs.monai.io/en/stable/apps.html#module-monai.apps.auto3dseg) for more information.\n",
+    "\n",
+    "NOTE: **Auto3DSeg** ensemble uses multiple GPUs by default.\n",
+    "Please avoid allocating more GPUs than the number of files, e.g. use 2 GPUs but there is 1 file in `infer_files` or `file_slices`."
    ]
   },
   {
@@ -338,7 +348,6 @@
    "source": [
     "# set model ensemble method\n",
     "pred_params = {\n",
-    "    \"files_slices\": slice(0, 2),  # only infer the first two files in the testing data\n",
     "    \"mode\": \"vote\",  # use majority vote instead of mean to ensemble the predictions\n",
     "    \"sigmoid\": True,  # when to use sigmoid to binarize the prediction and output the label\n",
     "}\n",


### PR DESCRIPTION
Fixes #1360 .

### Description

Minor improvements

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.