### PR TITLE
Fix ensemble output file path in auto3dseg hello world notebook

### DIFF
--- a/auto3dseg/notebooks/auto3dseg_hello_world.ipynb
+++ b/auto3dseg/notebooks/auto3dseg_hello_world.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -21,6 +22,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -38,6 +40,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -64,6 +67,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -105,6 +109,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -142,6 +147,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -182,6 +188,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -209,6 +216,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -238,6 +246,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -254,6 +263,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -278,7 +288,7 @@
    ],
    "source": [
     "image_name = sim_datalist[\"testing\"][0][\"image\"].split(\".\")[0]\n",
-    "prediction_nib = nib.load(os.path.join(work_dir, \"ensemble_output\", image_name, image_name + \"_ensemble\" + \".nii.gz\"))\n",
+    "prediction_nib = nib.load(os.path.join(work_dir, \"ensemble_output\", image_name + \"_ensemble\" + \".nii.gz\"))\n",
     "pred = np.array(prediction_nib.dataobj)\n",
     "\n",
     "img_slice32 = lbl[32] == 0\n",
@@ -308,6 +318,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Fixes #1375 .

### Description

Fix pth

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
