### PR TITLE
Fix folder creation issues and wrong defaults (48g config) for 2D LDM tutorials

### DIFF
--- a/generative/2d_ldm/train_autoencoder.py
+++ b/generative/2d_ldm/train_autoencoder.py
@@ -39,7 +39,7 @@ def main():
     parser.add_argument(
         "-c",
         "--config-file",
-        default="./config/config_train_48g.json",
+        default="./config/config_train_32g.json",
         help="config json file that stores hyper-parameters",
     )
     parser.add_argument(

--- a/generative/2d_ldm/train_diffusion.py
+++ b/generative/2d_ldm/train_diffusion.py
@@ -40,7 +40,7 @@ def main():
     parser.add_argument(
         "-c",
         "--config-file",
-        default="./config/config_train_48g.json",
+        default="./config/config_train_32g.json",
         help="config json file that stores hyper-parameters",
     )
     parser.add_argument("-g", "--gpus", default=1, type=int, help="number of gpus per node")

--- a/generative/2d_ldm/utils.py
+++ b/generative/2d_ldm/utils.py
@@ -131,6 +131,7 @@ def prepare_brats2d_dataloader(
             EnsureTyped(keys="image", dtype=compute_dtype),
         ]
     )
+    os.makedirs(args.data_base_dir, exist_ok=True)
     train_ds = DecathlonDataset(
         root_dir=args.data_base_dir,
         task="Task01_BrainTumour",

--- a/generative/3d_ldm/inference.py
+++ b/generative/3d_ldm/inference.py
@@ -39,7 +39,7 @@ def main():
     parser.add_argument(
         "-c",
         "--config-file",
-        default="./config/config_train_48g.json",
+        default="./config/config_train_32g.json",
         help="config json file that stores hyper-parameters",
     )
     parser.add_argument(

--- a/generative/3d_ldm/utils.py
+++ b/generative/3d_ldm/utils.py
@@ -99,6 +99,7 @@ def prepare_dataloader(
             EnsureTyped(keys="image", dtype=compute_dtype),
         ]
     )
+    os.makedirs(args.data_base_dir, exist_ok=True)
     train_ds = DecathlonDataset(
         root_dir=args.data_base_dir,
         task="Task01_BrainTumour",


### PR DESCRIPTION
Fixes #1384 .

### Description

Add `os.makedirs` before using the folder

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.

