### PR TITLE
1366-fix-deepatlas-ssim-loss-issue

### DIFF
--- a/deep_atlas/deep_atlas_tutorial.ipynb
+++ b/deep_atlas/deep_atlas_tutorial.ipynb
@@ -28,8 +28,6 @@
     "\n",
     "This notebook works with 3D images and segmentations, and it results in two trained models: a segmentation network `seg_net` and a registration network `reg_net`. There are two training phases: a pre-training phase for the segmentation network alone, and an alternating training phase for the two networks together. Use of the trained models for inference is demonstrated at the end of the notebook.\n",
     "\n",
-    "Please note that this notebook is verified to work well on the NVIDIA H100/A100/V100 GPU. However, there is a problem in the `Train Networks` part when running on the NVIDIA L40/3090Ti/3080Ti GPU. Track this [issue](https://github.com/Project-MONAI/tutorials/issues/1336) for more detail.\n",
-    "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/tutorials/blob/main/deep_atlas/deep_atlas_tutorial.ipynb)\n",
     "\n",
     "---\n",
@@ -146,9 +144,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "576b9aa6",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -214,6 +210,11 @@
     "\n",
     "# Set deterministic training for reproducibility\n",
     "monai.utils.set_determinism(seed=2938649572)\n",
+    "\n",
+    "# Turn off the TF32 precision. Otherwise, because of the rounding error, the ssim_loss will be a weird value on some Ampere GPUs, like L40, 3090Ti and 3080Ti.\n",
+    "# Track this issue (https://github.com/Project-MONAI/tutorials/issues/1336) for more detail.\n",
+    "torch.backends.cuda.matmul.allow_tf32 = False\n",
+    "torch.backends.cudnn.allow_tf32 = False\n",
     "\n",
     "monai.config.print_config()"
    ]
@@ -718,9 +719,7 @@
    "cell_type": "code",
    "execution_count": 16,
    "id": "0a020fc2",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1233,9 +1232,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fbbc25b5",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Training cell\n",
@@ -1605,9 +1602,7 @@
    "cell_type": "code",
    "execution_count": 39,
    "id": "11402c6e",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The following are dictionaries that map segmentation availability labels 00,10,01,11 to MONAI dataloaders\n",
@@ -1690,9 +1685,7 @@
    "cell_type": "code",
    "execution_count": 41,
    "id": "bfdacfa6",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1718,7 +1711,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c95101e5",
    "metadata": {},
@@ -1758,9 +1750,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ef8af785",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Training cell\n",
@@ -1954,9 +1944,7 @@
    "cell_type": "code",
    "execution_count": 43,
    "id": "050dd7b0",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2169,9 +2157,7 @@
    "cell_type": "code",
    "execution_count": 60,
    "id": "5801a48e",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2489,7 +2475,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #1336 .

Turn off the TF32 precision in this tutorial to fix the ssim loss issue caused by the rounding error.

### Description
A few sentences describing the changes proposed in this pull request.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
