### PR TITLE
Fix type error in `performance_profiling/pathology/train_evaluate_nvtx.py`

### DIFF
--- a/performance_profiling/pathology/train_evaluate_nvtx.py
+++ b/performance_profiling/pathology/train_evaluate_nvtx.py
@@ -477,6 +477,9 @@ def main(cfg):
     # Save final metrics
     metric_summary["train_time_per_epoch"] = total_train_time / cfg["n_epochs"]
     metric_summary["total_time"] = t_end - t_start
+
+    # The type of the value in hparam_dict can only be one of bool, string, float, int, or None.
+    cfg["grid_shape"] = str(cfg["grid_shape"])
     writer.add_hparams(hparam_dict=cfg, metric_dict=metric_summary, run_name=log_dir)
     writer.close()
     logging.info(f"Metric Summary: {metric_summary}")


### PR DESCRIPTION
Fixes #1415 .

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
