### PR TITLE
Add zarr merger notebook section

### DIFF
--- a/patch_inferer/modular_patch_inferer.ipynb
+++ b/patch_inferer/modular_patch_inferer.ipynb
@@ -553,6 +553,14 @@
    "metadata": {},
    "source": [
     "## Zarr Merger\n",
+    "Zarr is a format for the storage of chunked, compressed, N-dimensional arrays.\n",
+    "Zarr data can be stored in any storage system that can be represented as a key-value store,\n",
+    "like POSIX file systems, cloud object storage, zip files, and relational and document databases.\n",
+    "See https://zarr.readthedocs.io/en/stable/ for more details.\n",
+    "\n",
+    "It is particularly useful for storing N-dimensional arrays too large to fit into memory, and here for whole slide images (WSI),\n",
+    "where the merged output may not fit into memory and needs to be stored on a file system.\n",
+    "\n",
     "Similar ro any `Merger`, `ZarrAvgMerger` can be used simply by plugging it into `PatchInferer`."
    ]
   },

--- a/patch_inferer/modular_patch_inferer.ipynb
+++ b/patch_inferer/modular_patch_inferer.ipynb
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow,tqdm,cucim,zarr]\"\n",
-    "!python -c \"import matplotlib\" || pip install -q matplotlib\n"
+    "!python -c \"import matplotlib\" || pip install -q matplotlib"
    ]
   },
   {
@@ -111,7 +111,7 @@
     "from monai.inferers import AvgMerger, PatchInferer, SlidingWindowSplitter, WSISlidingWindowSplitter, ZarrAvgMerger\n",
     "from monai.transforms import LoadImage, Compose, EnsureChannelFirst, AsChannelLast\n",
     "\n",
-    "print_config()\n"
+    "print_config()"
    ]
   },
   {
@@ -150,7 +150,7 @@
     "    for inputs in DataLoader(dataset):\n",
     "        out = inferer(inputs, network)\n",
     "        outputs.append(out)\n",
-    "    return outputs\n"
+    "    return outputs"
    ]
   },
   {
@@ -183,8 +183,7 @@
     "\n",
     "\n",
     "# Download the image and create file path list\n",
-    "IMAGE_URLS = [\n",
-    "    \"https://github.com/Project-MONAI/MONAI/raw/dev/tests/testing_data/kitty_test.jpg\"]\n",
+    "IMAGE_URLS = [\"https://github.com/Project-MONAI/MONAI/raw/dev/tests/testing_data/kitty_test.jpg\"]\n",
     "IMAGE_PATH_LIST = []\n",
     "for url in IMAGE_URLS:\n",
     "    path = os.path.join(os.path.abspath(\".\"), os.path.basename(url))\n",
@@ -192,11 +191,10 @@
     "    IMAGE_PATH_LIST.append(path)\n",
     "\n",
     "# Transforms\n",
-    "transforms = Compose([LoadImage(\n",
-    "    reader=PILReader, reverse_indexing=False, image_only=True), EnsureChannelFirst()])\n",
+    "transforms = Compose([LoadImage(reader=PILReader, reverse_indexing=False, image_only=True), EnsureChannelFirst()])\n",
     "\n",
     "# Load input image (for plotting purposes only)\n",
-    "IMAGE = transforms(IMAGE_PATH_LIST)\n"
+    "IMAGE = transforms(IMAGE_PATH_LIST)"
    ]
   },
   {
@@ -245,18 +243,15 @@
     "axes[0].set_title(\"original\", fontsize=8)\n",
     "for i, overlap in enumerate(overlaps, 1):\n",
     "    inferer = PatchInferer(\n",
-    "        splitter=SlidingWindowSplitter(\n",
-    "            patch_size=patch_size, overlap=overlap, pad_mode=None),\n",
+    "        splitter=SlidingWindowSplitter(patch_size=patch_size, overlap=overlap, pad_mode=None),\n",
     "        merger_cls=AvgMerger,\n",
     "        match_spatial_shape=False,\n",
     "    )\n",
-    "    img = run_inference(inferer, network_random_brightness,\n",
-    "                        IMAGE_PATH_LIST, transforms)\n",
+    "    img = run_inference(inferer, network_random_brightness, IMAGE_PATH_LIST, transforms)\n",
     "    cat_plot(axes[i], img[0])\n",
     "    axes[i].set_title(f\"{overlap=}\", fontsize=8)\n",
     "\n",
-    "fig.suptitle(\n",
-    "    f\"Effect of overlap (without padding, {patch_size=})\", fontsize=12)\n"
+    "fig.suptitle(f\"Effect of overlap (without padding, {patch_size=})\", fontsize=12)"
    ]
   },
   {
@@ -308,20 +303,17 @@
     "for i, match_spatial_shape in enumerate(match_spatial_shapes):\n",
     "    for j, pad_mode in enumerate(pad_modes, 1):\n",
     "        inferer = PatchInferer(\n",
-    "            splitter=SlidingWindowSplitter(\n",
-    "                patch_size=patch_size, pad_mode=pad_mode),\n",
+    "            splitter=SlidingWindowSplitter(patch_size=patch_size, pad_mode=pad_mode),\n",
     "            merger_cls=AvgMerger,\n",
     "            match_spatial_shape=match_spatial_shape,\n",
     "        )\n",
-    "        img = run_inference(inferer, network_random_brightness,\n",
-    "                            IMAGE_PATH_LIST, transforms)\n",
+    "        img = run_inference(inferer, network_random_brightness, IMAGE_PATH_LIST, transforms)\n",
     "        ax = axes[i, j]\n",
     "        cat_plot(ax, img[0])\n",
     "        ax.set_title(f\"{pad_mode=}\", fontsize=16)\n",
     "        if j == 1:\n",
     "            ax.set_ylabel(f\"{match_spatial_shape=}\", fontsize=8)\n",
-    "fig.suptitle(\n",
-    "    f\" Effect of padding and matching spatial shape (without overlap, {patch_size=})\", fontsize=12)\n"
+    "fig.suptitle(f\" Effect of padding and matching spatial shape (without overlap, {patch_size=})\", fontsize=12)"
    ]
   },
   {
@@ -646,7 +638,7 @@
     "print(\"Chunk size:\", zarr_img.chunks)\n",
     "print(\"Number of chunk splits:\", zarr_img.cdata_shape)\n",
     "print(\"Total number of chunks:\", zarr_img.nchunks)\n",
-    "print(\"Chunk compressor:\", zarr_img.compressor)\n"
+    "print(\"Chunk compressor:\", zarr_img.compressor)"
    ]
   },
   {
@@ -767,8 +759,7 @@
    ],
    "source": [
     "inferer = PatchInferer(\n",
-    "    splitter=WSISlidingWindowSplitter(\n",
-    "        patch_size=patch_size, pad_mode=\"constant\", reader=WSI_BACKEND, level=WSI_LEVEL),\n",
+    "    splitter=WSISlidingWindowSplitter(patch_size=patch_size, pad_mode=\"constant\", reader=WSI_BACKEND, level=WSI_LEVEL),\n",
     "    merger_cls=ZarrAvgMerger,\n",
     "    match_spatial_shape=True,\n",
     "    store=zarr.storage.ZipStore(\"merged_output.zip\", mode=\"w\"),  # zip file\n",
@@ -796,12 +787,11 @@
    "outputs": [],
    "source": [
     "inferer = PatchInferer(\n",
-    "    splitter=WSISlidingWindowSplitter(\n",
-    "        patch_size=patch_size, pad_mode=\"constant\", reader=WSI_BACKEND, level=WSI_LEVEL),\n",
+    "    splitter=WSISlidingWindowSplitter(patch_size=patch_size, pad_mode=\"constant\", reader=WSI_BACKEND, level=WSI_LEVEL),\n",
     "    merger_cls=ZarrAvgMerger,\n",
     "    match_spatial_shape=True,\n",
-    "    compressor=zarr.codec_registry['lz4'](),\n",
-    "    value_compressor=zarr.codec_registry['zlib'](),\n",
+    "    compressor=zarr.codec_registry[\"lz4\"](),\n",
+    "    value_compressor=zarr.codec_registry[\"zlib\"](),\n",
     "    count_compressor=None,\n",
     ")\n",
     "img = run_inference(inferer, network_random_brightness, WSI_PATH_LIST)"

--- a/patch_inferer/modular_patch_inferer.ipynb
+++ b/patch_inferer/modular_patch_inferer.ipynb
@@ -48,6 +48,7 @@
    "outputs": [],
    "source": [
     "!python -c \"import monai\" || pip install -q \"monai-weekly[pillow,tqdm,cucim,zarr]\"\n",
+    "!python -c \"import zarr\" || pip install -q zarr\n",
     "!python -c \"import matplotlib\" || pip install -q matplotlib"
    ]
   },
@@ -835,7 +836,7 @@
     }
    ],
    "source": [
-    "print(f\"List of available chunk compressors:\")\n",
+    "print(\"List of available chunk compressors:\")\n",
     "print(\"\\n\".join(sorted(zarr.codec_registry.keys())))"
    ]
   }


### PR DESCRIPTION
This PR add an example for `ZarrAvgMerger` to be plugged into `PatchInferer` along with `WSISlidingWindowSplitter`.

Note: https://github.com/Project-MONAI/MONAI/pull/6633 in MONAI core should be merged before this one.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [x] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
