### PR TITLE
1439 Fix missing file in MICCAI tutorial

### DIFF
--- a/competitions/MICCAI/surgtoolloc/preprocess_detect_scene_and_split_fold.ipynb
+++ b/competitions/MICCAI/surgtoolloc/preprocess_detect_scene_and_split_fold.ipynb
@@ -125,6 +125,8 @@
     "    df[lb] = df.tools_present.str.count(lb)\n",
     "\n",
     "labels = df.columns.values[2:]\n",
+    "# uncomment the following line to produce the train.csv file\n",
+    "# df.to_csv('../train.csv', index=False)\n",
     "df.shape"
    ]
   },
@@ -155,7 +157,7 @@
     "df[\"frame\"] = df.img_path.apply(lambda x: int(x[:-4].split(\"_\")[-1]))\n",
     "df = df.sort_values([\"clip_name\", \"frame\"]).reset_index(drop=True)\n",
     "\n",
-    "df.shape"
+    "df.shape\n"
    ]
   },
   {

--- a/competitions/MICCAI/surgtoolloc/preprocess_detect_scene_and_split_fold.ipynb
+++ b/competitions/MICCAI/surgtoolloc/preprocess_detect_scene_and_split_fold.ipynb
@@ -157,7 +157,7 @@
     "df[\"frame\"] = df.img_path.apply(lambda x: int(x[:-4].split(\"_\")[-1]))\n",
     "df = df.sort_values([\"clip_name\", \"frame\"]).reset_index(drop=True)\n",
     "\n",
-    "df.shape\n"
+    "df.shape"
    ]
   },
   {


### PR DESCRIPTION
Fixes #1439 .

### Description
This PR is used to add the missing csv file producting in MICCAI tutorial.
### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
