### PR TITLE
clear data analyzer output for the bash cmd

### DIFF
--- a/auto3dseg/notebooks/data_analyzer.ipynb
+++ b/auto3dseg/notebooks/data_analyzer.ipynb
@@ -21,7 +21,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -214,7 +213,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -225,7 +223,7 @@
     "```bash\n",
     "python -m monai.apps.auto3dseg DataAnalyzer get_all_case_stats \\\n",
     "            --datalist=\"<datalist file path>\" \\\n",
-    "            --dataroot=\"<dataroot path>\"\n",
+    "            --dataroot=\"<dataroot path>\" > /dev/null\n",
     "```\n"
    ]
   }
@@ -246,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.16"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION

### Description
`python -m monai.apps.auto3dseg DataAnalyzer get_all_case_stats` will output all the data stats to stdout. this PR redirect these to `/dev/null`


### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
