### PR TITLE
1486 image dataset fix

### DIFF
--- a/modules/image_dataset.ipynb
+++ b/modules/image_dataset.ipynb
@@ -136,7 +136,7 @@
    ],
    "source": [
     "class TestCompose(Compose):\n",
-    "    def __call__(self, data, meta):\n",
+    "    def __call__(self, data, meta, **_kwargs):\n",
     "        data = self.transforms[0](data)  # ensure channel first\n",
     "        data = self.transforms[1](data)  # spacing\n",
     "        meta = data.meta\n",
@@ -192,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #1486 

customized Compose in image_dataset.ipynb is updated in this PR according to https://github.com/Project-MONAI/MONAI/pull/6878

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
