### PR TITLE
module 'aim' has no attribute 'Run'

### DIFF
--- a/experiment_management/spleen_segmentation_aim.ipynb
+++ b/experiment_management/spleen_segmentation_aim.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "!python -c \"import monai\" || pip install -q \"monai-weekly[gdown, nibabel, tqdm, ignite]\"\n",
     "!python -c \"import matplotlib\" || pip install matplotlib\n",
-    "!python -c \"from aim import Run\" || pip install aim"
+    "!python -c \"from aim import Run\" || pip install aim==3.17.5"
    ]
   },
   {
@@ -664,7 +664,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #1536

### Description
Stick aim==3.17.5 as a workaround.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
