### PR TITLE
fixes url; workaround to skip 1550

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -14,7 +14,7 @@ Start the tutorial notebooks on constructing bundles:
 2. [MedNIST Classification](./02_mednist_classification.ipynb): train a network using the bundle for doing a real task.
 3. [MedNIST Classification With Best Practices](./03_mednist_classification_v2.ipynb): do the same again but better.
 4. [Integrating Existing Code](./04_integrating_code.ipynb): discussion on how to integrate existing, possible non-MONAI, code into a bundle.
-5. [Spleen Segmentation using Pytorch Lightning](./05_spleen_segmentation.ipynb): train a segmentation network using MONAI bundle and Pytorch Lightning.
+5. [Spleen Segmentation using Pytorch Lightning](./05_spleen_segmentation_lightning.ipynb): train a segmentation network using MONAI bundle and Pytorch Lightning.
 
 More advanced topics are covered in this directory:
 

--- a/runner.sh
+++ b/runner.sh
@@ -124,6 +124,7 @@ skip_run_papermill=("${skip_run_papermill[@]}" .*nuclei_classification_training_
 skip_run_papermill=("${skip_run_papermill[@]}" .*nuclick_training_notebook.ipynb*)  # https://github.com/Project-MONAI/tutorials/issues/1542
 skip_run_papermill=("${skip_run_papermill[@]}" .*nuclei_classification_infer.ipynb*)  # https://github.com/Project-MONAI/tutorials/issues/1542
 skip_run_papermill=("${skip_run_papermill[@]}" .*nuclick_infer.ipynb*)  # https://github.com/Project-MONAI/tutorials/issues/1542
+skip_run_papermill=("${skip_run_papermill[@]}" .*05_spleen_segmentation_lightning.ipynb*)  # https://github.com/Project-MONAI/tutorials/issues/1550
 
 # output formatting
 separator=""


### PR DESCRIPTION
temporarily skip the test #1550 while we are improving the premerge runner.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
