### PR TITLE
fix bug varautoencoder_mednist.ipynb

### DIFF
--- a/modules/varautoencoder_mednist.ipynb
+++ b/modules/varautoencoder_mednist.ipynb
@@ -358,9 +358,9 @@
     "    ]\n",
     ")\n",
     "\n",
-    "train_ds = CacheDataset(train_datadict[:10], transforms, num_workers=num_workers)\n",
+    "train_ds = CacheDataset(train_datadict, transforms, num_workers=num_workers)\n",
     "train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=num_workers)\n",
-    "test_ds = CacheDataset(test_datadict[:10], transforms, num_workers=num_workers)\n",
+    "test_ds = CacheDataset(test_datadict, transforms, num_workers=num_workers)\n",
     "test_loader = DataLoader(test_ds, batch_size=batch_size, shuffle=True, num_workers=num_workers)"
    ]
   },


### PR DESCRIPTION
Bug in VAE tutorial, indexing of the data dictionaries train_datadict[:10] and test_datadict[:10] had been left there.

### Description
In a previous commit, someone left indexes on the data dictionaries train_datadict[:10] and test_datadict[:10] to debug. I removed them so the code properly runs on the whole dataset.

### Checks
