### PR TITLE
Add readme linking to Flower examples

### DIFF
--- a/federated_learning/flower/README.md
+++ b/federated_learning/flower/README.md
@@ -1,0 +1,4 @@
+# Federated learning with Flower
+[Flower](https://flower.ai/), a friendly federated learning framework, provides examples on how to train federated learning models using MONAI components.
+
+## Please visit [here](https://flower.ai/docs/examples/quickstart-monai.html) to get started.


### PR DESCRIPTION
Fixes #1657.

### Description
Add readme linking to Flower examples. CC @danieljanes, @jafermarq, @tanertopal

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
