### PR TITLE
Fix image download name error in profiling_camelyon_pipeline.ipynb

### DIFF
--- a/pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb
+++ b/pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb
@@ -139,7 +139,7 @@
     "if not os.path.exists(image_dir):\n",
     "    os.makedirs(image_dir)\n",
     "image_url = \"https://drive.google.com/uc?id=1OxAeCMVqH9FGpIWpAXSEJe6cLinEGQtF\"\n",
-    "gdown.download(image_url, image_dir, quiet=False)"
+    "gdown.download(image_url, f\"{image_dir}/tumor_091.tif\", quiet=False)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #1660


### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
