### PR TITLE
Update tutorials under reconstruction folder

### DIFF
--- a/detection/generate_transforms.py
+++ b/detection/generate_transforms.py
@@ -78,7 +78,7 @@ def generate_detection_train_transform(
 
     train_transforms = Compose(
         [
-            LoadImaged(keys=[image_key], meta_key_postfix="meta_dict"),
+            LoadImaged(keys=[image_key], image_only=False, meta_key_postfix="meta_dict"),
             EnsureChannelFirstd(keys=[image_key]),
             EnsureTyped(keys=[image_key, box_key], dtype=torch.float32),
             EnsureTyped(keys=[label_key], dtype=torch.long),
@@ -224,7 +224,7 @@ def generate_detection_val_transform(
 
     val_transforms = Compose(
         [
-            LoadImaged(keys=[image_key], meta_key_postfix="meta_dict"),
+            LoadImaged(keys=[image_key], image_only=False, meta_key_postfix="meta_dict"),
             EnsureChannelFirstd(keys=[image_key]),
             EnsureTyped(keys=[image_key, box_key], dtype=torch.float32),
             EnsureTyped(keys=[label_key], dtype=torch.long),
@@ -280,7 +280,7 @@ def generate_detection_inference_transform(
 
     test_transforms = Compose(
         [
-            LoadImaged(keys=[image_key], meta_key_postfix="meta_dict"),
+            LoadImaged(keys=[image_key], image_only=False, meta_key_postfix="meta_dict"),
             EnsureChannelFirstd(keys=[image_key]),
             EnsureTyped(keys=[image_key], dtype=torch.float32),
             Orientationd(keys=[image_key], axcodes="RAS"),

--- a/detection/luna16_prepare_images.py
+++ b/detection/luna16_prepare_images.py
@@ -61,6 +61,7 @@ def main():
         [
             LoadImaged(
                 keys=["image"],
+                image_only=False,
                 meta_key_postfix="meta_dict",
                 reader="itkreader",
                 affine_lps_to_ras=True,

--- a/detection/luna16_prepare_images_dicom.py
+++ b/detection/luna16_prepare_images_dicom.py
@@ -63,6 +63,7 @@ def main():
         [
             LoadImaged(
                 keys=["image"],
+                image_only=False,
                 meta_key_postfix="meta_dict",
                 reader="itkreader",
                 affine_lps_to_ras=True,

--- a/reconstruction/MRI_reconstruction/unet_demo/inference.ipynb
+++ b/reconstruction/MRI_reconstruction/unet_demo/inference.ipynb
@@ -236,7 +236,7 @@
     "\n",
     "test_transforms = Compose(\n",
     "    [\n",
-    "        LoadImaged(keys=[\"kspace\"], reader=FastMRIReader, dtype=np.complex64),\n",
+    "        LoadImaged(keys=[\"kspace\"], reader=FastMRIReader, image_only=False, dtype=np.complex64),\n",
     "        # user can also add other random transforms\n",
     "        ExtractDataKeyFromMetaKeyd(keys=[\"reconstruction_rss\", \"mask\"], meta_key=\"kspace_meta_dict\"),\n",
     "        MaskTransform,\n",

--- a/reconstruction/MRI_reconstruction/unet_demo/train.py
+++ b/reconstruction/MRI_reconstruction/unet_demo/train.py
@@ -97,7 +97,7 @@ def trainer(args):
 
     train_transforms = Compose(
         [
-            LoadImaged(keys=["kspace"], reader=FastMRIReader, dtype=np.complex64),
+            LoadImaged(keys=["kspace"], reader=FastMRIReader, image_only=False, dtype=np.complex64),
             # user can also add other random transforms
             ExtractDataKeyFromMetaKeyd(keys=["reconstruction_rss", "mask"], meta_key="kspace_meta_dict"),
             MaskTransform,

--- a/reconstruction/MRI_reconstruction/varnet_demo/inference.ipynb
+++ b/reconstruction/MRI_reconstruction/varnet_demo/inference.ipynb
@@ -251,7 +251,7 @@
     "\n",
     "test_transforms = Compose(\n",
     "    [\n",
-    "        LoadImaged(keys=[\"kspace\"], reader=FastMRIReader, dtype=np.complex64),\n",
+    "        LoadImaged(keys=[\"kspace\"], reader=FastMRIReader, image_only=False, dtype=np.complex64),\n",
     "        # user can also add other random transforms\n",
     "        ExtractDataKeyFromMetaKeyd(keys=[\"reconstruction_rss\", \"mask\"], meta_key=\"kspace_meta_dict\"),\n",
     "        MaskTransform,\n",

--- a/reconstruction/MRI_reconstruction/varnet_demo/train.py
+++ b/reconstruction/MRI_reconstruction/varnet_demo/train.py
@@ -106,7 +106,7 @@ def trainer(args):
 
     train_transforms = Compose(
         [
-            LoadImaged(keys=["kspace"], reader=FastMRIReader, dtype=np.complex64),
+            LoadImaged(keys=["kspace"], reader=FastMRIReader, image_only=False, dtype=np.complex64),
             # user can also add other random transforms but remember to disable randomness for val_transforms
             ExtractDataKeyFromMetaKeyd(keys=["reconstruction_rss", "mask"], meta_key="kspace_meta_dict"),
             MaskTransform,


### PR DESCRIPTION
Fixes #1670

### Description
Set "image_only=False" in `LoadImage`.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
