### PR TITLE
Fix failure to override num_epochs for auto3dseg HPO demo

### DIFF
--- a/auto3dseg/notebooks/auto_runner.ipynb
+++ b/auto3dseg/notebooks/auto_runner.ipynb
@@ -448,7 +448,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runner = AutoRunner(input=input, hpo=True, ensemble=False)\n",
+    "runner = AutoRunner(input=input, algos=('segresnet'), hpo=True, ensemble=False)\n",
     "num_epoch = 2\n",
     "hpo_params = {\n",
     "    \"maxTrialNumber\": 20,\n",
@@ -462,6 +462,8 @@
     "    \"searching#num_epochs\": 2,\n",
     "    \"searching#num_epochs_per_validation\": 1,\n",
     "    \"searching#num_warmup_epochs\": 1,\n",
+    "    \"training#auto_scale_allowed\": False,  # disable the auto scale so that num_epochs can be set\n",
+    "    \"auto_scale_allowed\": False,  # disable the auto scale so that num_epochs can be set\n",
     "}\n",
     "search_space = {\"learning_rate\": {\"_type\": \"choice\", \"_value\": [0.0001, 0.01]}}\n",
     "runner.set_num_fold(num_fold=1)\n",

--- a/auto3dseg/notebooks/auto_runner.ipynb
+++ b/auto3dseg/notebooks/auto_runner.ipynb
@@ -448,7 +448,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runner = AutoRunner(input=input, algos=('segresnet'), hpo=True, ensemble=False)\n",
+    "runner = AutoRunner(input=input, algos=(\"segresnet\"), hpo=True, ensemble=False)\n",
     "num_epoch = 2\n",
     "hpo_params = {\n",
     "    \"maxTrialNumber\": 20,\n",


### PR DESCRIPTION
Partly fixes #1679 for HPO, and limit the models for HPO demo.

### Description
A few sentences describing the changes proposed in this pull request.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [x] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
