### PR TITLE
Update Orthanc installation URL

### DIFF
--- a/monailabel/monailabel_radiology_spleen_segmentation_OHIF.ipynb
+++ b/monailabel/monailabel_radiology_spleen_segmentation_OHIF.ipynb
@@ -38,12 +38,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "!pip install monailabel"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -55,12 +55,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "!monailabel apps --download --name radiology --output apps"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -80,12 +80,12 @@
     "sudo service orthanc stop\n",
     "\n",
     "# setup and upgrade Orthanc libraries\n",
-    "sudo wget https://lsb.orthanc-server.com/orthanc/1.9.7/Orthanc --output-document /usr/sbin/Orthanc\n",
+    "sudo wget https://orthanc.uclouvain.be/downloads/linux-standard-base/orthanc/1.12.3/Orthanc --output-document /usr/sbin/Orthanc\n",
     "sudo rm -f /usr/share/orthanc/plugins/*.so\n",
     "\n",
-    "sudo wget https://lsb.orthanc-server.com/orthanc/1.9.7/libServeFolders.so --output-document /usr/share/orthanc/plugins/libServeFolders.so\n",
-    "sudo wget https://lsb.orthanc-server.com/orthanc/1.9.7/libModalityWorklists.so --output-document /usr/share/orthanc/plugins/libModalityWorklists.so\n",
-    "sudo wget https://lsb.orthanc-server.com/plugin-dicom-web/1.6/libOrthancDicomWeb.so --output-document /usr/share/orthanc/plugins/libOrthancDicomWeb.so\n",
+    "sudo wget https://orthanc.uclouvain.be/downloads/linux-standard-base/orthanc/1.12.3/libServeFolders.so --output-document /usr/share/orthanc/plugins/libServeFolders.so\n",
+    "sudo wget https://orthanc.uclouvain.be/downloads/linux-standard-base/orthanc/1.12.3/libModalityWorklists.so --output-document /usr/share/orthanc/plugins/libModalityWorklists.so\n",
+    "sudo wget https://orthanc.uclouvain.be/downloads/linux-standard-base/orthanc-dicomweb/1.16/libOrthancDicomWeb.so --output-document /usr/share/orthanc/plugins/libOrthancDicomWeb.so\n",
     "\n",
     "# start\n",
     "sudo service orthanc restart\n",
@@ -113,12 +113,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "!monailabel datasets --download --name Task09_Spleen --output datasets"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -131,9 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "# Install `pyplastimatch` NIFTI to DICOM converter\n",
     "!pip install pyplastimatch\n",
@@ -150,7 +148,9 @@
     "    \"output-dicom\": \"dicom_output\",\n",
     "}\n",
     "pypla.convert(verbose=True, **convert_args_ct)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -191,12 +191,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "!monailabel start_server --app apps/radiology --studies http://127.0.0.1:8042/dicom-web --conf models segmentation_spleen"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
### Description
Replaced the deprecated Orthanc installation URL with the updated one from UCLouvain, ensuring proper setup of Orthanc libraries.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
