### PR TITLE
Fix KeyError in ./pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb

### DIFF
--- a/pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb
+++ b/pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb
@@ -542,6 +542,7 @@
     "\n",
     "# Set the Range (which is the name of each range) as the index\n",
     "summary.set_index(\"Range\", inplace=True)\n",
+    "summary.index = summary.index.str.lstrip(':')\n",
     "\n",
     "# Get the entries for training transforms only (to avoid nested ranges)\n",
     "summary = summary.loc[transforms]\n",

--- a/pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb
+++ b/pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb
@@ -542,7 +542,7 @@
     "\n",
     "# Set the Range (which is the name of each range) as the index\n",
     "summary.set_index(\"Range\", inplace=True)\n",
-    "summary.index = summary.index.str.lstrip(':')\n",
+    "summary.index = summary.index.str.lstrip(\":\")\n",
     "\n",
     "# Get the entries for training transforms only (to avoid nested ranges)\n",
     "summary = summary.loc[transforms]\n",


### PR DESCRIPTION
Fixes #1810

Fix KeyError in ./pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
