### PR TITLE
Remove installation section in ldm2d and ldm3d readme

### DIFF
--- a/deployment/Triton/client/client.py
+++ b/deployment/Triton/client/client.py
@@ -51,7 +51,7 @@ import glob
 from monai.apps.utils import download_and_extract
 
 model_name = "monai_covid"
-gdrive_path = "https://drive.google.com/uc?id=1GYvHGU2jES0m_msin-FFQnmTOaHkl0LN"
+gdrive_path = "https://developer.download.nvidia.com/assets/Clara/monai/tutorials/covid19_compressed.tar.gz"
 covid19_filename = "covid19_compress.tar.gz"
 md5_check = "cadd79d5ca9ccdee2b49cd0c8a3e6217"
 

--- a/deployment/Triton/client/client_mednist.py
+++ b/deployment/Triton/client/client_mednist.py
@@ -55,7 +55,7 @@ MEDNIST_CLASSES = ["AbdomenCT", "BreastMRI", "CXR", "ChestCT", "Hand", "HeadCT"]
 
 
 model_name = "mednist_class"
-gdrive_path = "https://drive.google.com/uc?id=1HQk4i4vXKUX_aAYR4wcZQKd-qk5Lcm_W"
+gdrive_path = "https://developer.download.nvidia.com/assets/Clara/monai/tutorials/MedNIST_demo.tar.gz"
 mednist_filename = "MedNIST_demo.tar.gz"
 md5_check = "3f24a5833bb0455a7815c4e0ecc8a810"
 

--- a/deployment/Triton/models/mednist_class/1/model.py
+++ b/deployment/Triton/models/mednist_class/1/model.py
@@ -74,7 +74,7 @@ MEDNIST_CLASSES = ["AbdomenCT", "BreastMRI", "CXR", "ChestCT", "Hand", "HeadCT"]
 
 
 logger = logging.getLogger(__name__)
-gdrive_url = "https://drive.google.com/uc?id=1c6noLV9oR0_mQwrsiQ9TqaaeWFKyw46l"
+gdrive_url = "https://developer.download.nvidia.com/assets/Clara/monai/tutorials/MedNist_model.tar.gz"
 model_filename = "MedNIST_model.tar.gz"
 md5_check = "a4fb9d6147599e104b5d8dc1809ed034"
 

--- a/deployment/Triton/models/monai_covid/1/model.py
+++ b/deployment/Triton/models/monai_covid/1/model.py
@@ -64,7 +64,7 @@ import triton_python_backend_utils as pb_utils
 
 
 logger = logging.getLogger(__name__)
-gdrive_url = "https://drive.google.com/uc?id=1U9Oaw47SWMJeDkg1FSTY1W__tQOY1nAZ"
+gdrive_url = "https://developer.download.nvidia.com/assets/Clara/monai/tutorials/covid19_model.tar.gz"
 model_filename = "covid19_model.tar.gz"
 md5_check = "571046a25659515bf7abee4266f14435"
 

--- a/generation/2d_ldm/README.md
+++ b/generation/2d_ldm/README.md
@@ -26,12 +26,9 @@ python download_brats_data.py -e ./config/environment.json
 
 Disclaimer: We are not the host of the data. Please make sure to read the requirements and usage policies of the data and give credit to the authors of the dataset!
 
-### 2. Installation
-Please refer to the [Installation of MONAI Generative Model](../README.md)
+### 2. Run the example
 
-### 3. Run the example
-
-#### [3.1 2D Autoencoder Training](./train_autoencoder.py)
+#### [2.1 2D Autoencoder Training](./train_autoencoder.py)
 
 The network configuration files are located in [./config/config_train_32g.json](./config/config_train_32g.json) for 32G GPU and [./config/config_train_16g.json](./config/config_train_16g.json) for 16G GPU. You can modify the hyperparameters in these files to suit your requirements.
 
@@ -74,7 +71,7 @@ An example reconstruction result is shown below:
   <img src="./figs/recon.png" alt="Autoencoder reconstruction result")
 </p>
 
-#### [3.2 2D Latent Diffusion Training](./train_diffusion.py)
+#### [2.2 2D Latent Diffusion Training](./train_diffusion.py)
 The training script uses the batch size and patch size defined in the configuration files. If you have a different GPU memory size, you should adjust the `"batch_size"` and `"patch_size"` parameters in the `"diffusion_train"` to match your GPU. Note that the `"patch_size"` needs to be divisible by 16 and no larger than 256.
 
 To train with single 32G GPU, please run:
@@ -97,7 +94,7 @@ torchrun \
   <img src="./figs/val_diffusion.png" alt="latent diffusion validation curve" width="45%" >
 </p>
 
-#### [3.3 Inference](./inference.py)
+#### [2.3 Inference](./inference.py)
 To generate one image during inference, please run the following command:
 ```bash
 python inference.py -c ./config/config_train_32g.json -e ./config/environment.json --num 1
@@ -115,7 +112,7 @@ An example output is shown below.
   <img src="./figs/syn_3.jpeg" width="20%" >
 </p>
 
-### 4. Questions and bugs
+### 3. Questions and bugs
 
 - For questions relating to the use of MONAI, please use our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
 - For bugs relating to MONAI functionality, please create an issue on the [main repository](https://github.com/Project-MONAI/MONAI/issues).

--- a/generation/3d_ldm/README.md
+++ b/generation/3d_ldm/README.md
@@ -26,12 +26,9 @@ python download_brats_data.py -e ./config/environment.json
 
 Disclaimer: We are not the host of the data. Please make sure to read the requirements and usage policies of the data and give credit to the authors of the dataset!
 
-### 2. Installation
-Please refer to the [Installation of MONAI Generative Model](../README.md)
+### 2. Run the example
 
-### 3. Run the example
-
-#### [3.1 3D Autoencoder Training](./train_autoencoder.py)
+#### [2.1 3D Autoencoder Training](./train_autoencoder.py)
 
 The network configuration files are located in [./config/config_train_32g.json](./config/config_train_32g.json) for 32G GPU
 and [./config/config_train_16g.json](./config/config_train_16g.json) for 16G GPU.
@@ -73,7 +70,7 @@ torchrun \
 
 With eight DGX1V 32G GPUs, it took around 55 hours to train 1000 epochs.
 
-#### [3.2 3D Latent Diffusion Training](./train_diffusion.py)
+#### [2.2 3D Latent Diffusion Training](./train_diffusion.py)
 The training script uses the batch size and patch size defined in the configuration files. If you have a different GPU memory size, you should adjust the `"batch_size"` and `"patch_size"` parameters in the `"diffusion_train"` to match your GPU. Note that the `"patch_size"` needs to be divisible by 16.
 
 To train with single 32G GPU, please run:
@@ -96,7 +93,7 @@ torchrun \
   <img src="./figs/val_diffusion.png" alt="latent diffusion validation curve" width="45%" >
 </p>
 
-#### [3.3 Inference](./inference.py)
+#### [2.3 Inference](./inference.py)
 To generate one image during inference, please run the following command:
 ```bash
 python inference.py -c ./config/config_train_32g.json -e ./config/environment.json --num 1
@@ -112,7 +109,7 @@ An example output is shown below.
   <img src="./figs/syn_cor.png" width="30%" >
 </p>
 
-### 4. Questions and bugs
+### 3. Questions and bugs
 
 - For questions relating to the use of MONAI, please use our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
 - For bugs relating to MONAI functionality, please create an issue on the [main repository](https://github.com/Project-MONAI/MONAI/issues).

--- a/modules/developer_guide.ipynb
+++ b/modules/developer_guide.ipynb
@@ -717,7 +717,7 @@
     "id": "kvn_6mf9gZoA"
    },
    "source": [
-    "The following commands will start a `SupervisedTrainer` instance. As an extension of Pytorch ignite's facilities, it combines all the elements mentioned before. Calling `trainer.run()` will train the network for two epochs and compute `MeadDice` metric based on the training data at the end of every epoch.\n",
+    "The following commands will start a `SupervisedTrainer` instance. As an extension of Pytorch ignite's facilities, it combines all the elements mentioned before. Calling `trainer.run()` will train the network for two epochs and compute `MeanDice` metric based on the training data at the end of every epoch.\n",
     "\n",
     "The `key_train_metric` is used to track the progress of model quality improvement. Additional handlers could be set to do early stopping and learning rate scheduling.\n",
     "\n",

--- a/modules/interpretability/class_lung_lesion.ipynb
+++ b/modules/interpretability/class_lung_lesion.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "For the demo data:\n",
     "- Please see the `bbox_gen.py` script for generating the patch classification data from MSD task06_lung (available via `monai.apps.DecathlonDataset`);\n",
-    "- Alternatively, the patch dataset (~130MB) is available for direct downloading at: https://drive.google.com/drive/folders/1pQdzdkkC9c2GOblLgpGlG3vxsSK9NtDx\n",
+    "- Alternatively, the patch dataset (~130MB) is available for direct downloading at: https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/lung_lesion_patches.tar.gz\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/tutorials/blob/main/modules/interpretability/class_lung_lesion.ipynb)"
    ]

--- a/modules/tcia_csv_processing.ipynb
+++ b/modules/tcia_csv_processing.ipynb
@@ -247,8 +247,8 @@
    "metadata": {},
    "source": [
     "## Download and Load the CSV file with `TCIADataset`\n",
-    "Here we use the demo data in Google drive:\n",
-    "https://drive.google.com/file/d/1HQ7BZvBr1edmi8HIwdG5KBweXWms5Uzk/view?usp=sharing \n",
+    "Here we use the demo data located here:\n",
+    "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/ISPY1_Combined.csv \n",
     "\n",
     "Expect the first row of CSV file to be titles of columns. we only use the first 8 rows to execute demo processing."
    ]


### PR DESCRIPTION
Remove installation section in ldm2d and ldm3d readme for two reasons:
- No extra dependency need for this two tutorials for now.
- The link will be broken if we don't include the README file from the upper level.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
