### PR TITLE
Remove deprecated `pos_embed`

### DIFF
--- a/3d_segmentation/unetr_btcv_segmentation_3d.ipynb
+++ b/3d_segmentation/unetr_btcv_segmentation_3d.ipynb
@@ -586,7 +586,7 @@
     "    hidden_size=768,\n",
     "    mlp_dim=3072,\n",
     "    num_heads=12,\n",
-    "    pos_embed=\"perceptron\",\n",
+    "    proj_type=\"perceptron\",\n",
     "    norm_name=\"instance\",\n",
     "    res_block=True,\n",
     "    dropout_rate=0.0,\n",

--- a/3d_segmentation/unetr_btcv_segmentation_3d_lightning.ipynb
+++ b/3d_segmentation/unetr_btcv_segmentation_3d_lightning.ipynb
@@ -423,7 +423,7 @@
     "            hidden_size=768,\n",
     "            mlp_dim=3072,\n",
     "            num_heads=12,\n",
-    "            pos_embed=\"perceptron\",\n",
+    "            proj_type=\"perceptron\",\n",
     "            norm_name=\"instance\",\n",
     "            res_block=True,\n",
     "            conv_block=True,\n",

--- a/deepedit/ignite/train.py
+++ b/deepedit/ignite/train.py
@@ -76,7 +76,7 @@ def get_network(network, labels, spatial_size):
             hidden_size=1536,
             mlp_dim=3072,
             num_heads=48,
-            pos_embed="conv",
+            proj_type="conv",
             norm_name="instance",
             res_block=True,
         )

--- a/self_supervised_pretraining/vit_unetr_ssl/multi_gpu/mgpu_ssl_train.py
+++ b/self_supervised_pretraining/vit_unetr_ssl/multi_gpu/mgpu_ssl_train.py
@@ -175,7 +175,7 @@ def main(args):
         in_channels=1,
         img_size=(96, 96, 96),
         patch_size=(16, 16, 16),
-        pos_embed="conv",
+        proj_type="conv",
         hidden_size=768,
         mlp_dim=3072,
     )

--- a/self_supervised_pretraining/vit_unetr_ssl/ssl_finetune.ipynb
+++ b/self_supervised_pretraining/vit_unetr_ssl/ssl_finetune.ipynb
@@ -317,7 +317,7 @@
     "    hidden_size=768,\n",
     "    mlp_dim=3072,\n",
     "    num_heads=12,\n",
-    "    pos_embed=\"conv\",\n",
+    "    proj_type=\"conv\",\n",
     "    norm_name=\"instance\",\n",
     "    res_block=True,\n",
     "    dropout_rate=0.0,\n",

--- a/self_supervised_pretraining/vit_unetr_ssl/ssl_train.ipynb
+++ b/self_supervised_pretraining/vit_unetr_ssl/ssl_train.ipynb
@@ -253,7 +253,7 @@
     "    in_channels=1,\n",
     "    img_size=(96, 96, 96),\n",
     "    patch_size=(16, 16, 16),\n",
-    "    pos_embed=\"conv\",\n",
+    "    proj_type=\"conv\",\n",
     "    hidden_size=768,\n",
     "    mlp_dim=3072,\n",
     ")\n",


### PR DESCRIPTION


### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
