### PR TITLE
Update max_epochs to be int

### DIFF
--- a/generation/anomaly_detection/2d_classifierfree_guidance_anomalydetection_tutorial.ipynb
+++ b/generation/anomaly_detection/2d_classifierfree_guidance_anomalydetection_tutorial.ipynb
@@ -426,7 +426,7 @@
    },
    "source": [
     "condition_dropout = 0.15\n",
-    "max_epochs = 2e4\n",
+    "max_epochs = 20000\n",
     "batch_size = 64\n",
     "val_interval = 100\n",
     "iter_loss_list = []\n",


### PR DESCRIPTION
Fix max_epochs not correctly update in this tutorial:
https://github.com/Project-MONAI/tutorials/blob/main/generation/anomaly_detection/2d_classifierfree_guidance_anomalydetection_tutorial.ipynb?short_path=1f8100f#L429

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
