### PR TITLE
Increase duration in nsys profile 

### DIFF
--- a/pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb
+++ b/pathology/tumor_detection/ignite/profiling_camelyon_pipeline.ipynb
@@ -159,7 +159,7 @@
     "!nsys profile \\\n",
     "    --trace nvtx,osrt,cudnn,cuda, \\\n",
     "    --delay 5 \\\n",
-    "    --duration 10 \\\n",
+    "    --duration 20 \\\n",
     "    --show-output true \\\n",
     "    --force-overwrite true \\\n",
     "    --output profile_report.nsys-rep \\\n",


### PR DESCRIPTION
Fixes #1905 

Increase the profiling duration in nsys, as the KeyError seems to occur because the profile did not have sufficient time to reach the post-processing step.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
