### PR TITLE
Incorrectly states in tutorials train_controlnet

### DIFF
--- a/generation/maisi/maisi_train_controlnet_tutorial.ipynb
+++ b/generation/maisi/maisi_train_controlnet_tutorial.ipynb
@@ -166,7 +166,7 @@
     "            \"image\": \"tr_image_001_emb.nii.gz\",  # relative path to the image embedding file\n",
     "            # relative path to the combined label (pseudo whole-body segmentation mask + ROI mask) file\n",
     "            \"label\": \"tr_label_001.nii.gz\",\n",
-    "            \"fold\": 0,  # fold index for cross validation, fold 0 is used for training\n",
+    "            \"fold\": 0,  # fold index for cross validation. If the dataset item's fold value is equal to the fold value in config_maisi_controlnet_train.json, then it is used for validation. Otherwise, it is used for training. In the current parameters, fold 0 is for validation and fold 1 is for training.\n",
     "            \"dim\": sim_dim,  # the dimension of image\n",
     "            \"spacing\": [1.5, 1.5, 1.5],  # the spacing of image\n",
     "            \"top_region_index\": [0, 1, 0, 0],  # the top region index of the image\n",


### PR DESCRIPTION
Fixes # .

### Description
The current documentation incorrectly states that "fold 0 is used for training" in the `prepare_maisi_controlnet_json_dataloader` function. In reality, the function uses the `fold` parameter to determine the validation set based on matching fold indices. Specifically, if a dataset item's `fold` value matches the `fold` value specified in `config_maisi_controlnet_train.json`, it is assigned to the validation set; otherwise, it is used for training.

### Changes

- **Updated Documentation:**
  - Revised the description of the `fold` parameter to accurately reflect its functionality.
  - Clarified that in the current parameter settings, `fold 0` is designated for validation and `fold 1` is designated for training.
