### PR TITLE
fix: handle metadata loading and shape calculation in transforms

### DIFF
--- a/modules/dynunet_pipeline/transforms.py
+++ b/modules/dynunet_pipeline/transforms.py
@@ -40,7 +40,7 @@ def get_task_transforms(mode, task_id, pos_sample_num, neg_sample_num, num_sampl
         keys = ["image", "label"]
     else:
         keys = ["image"]
-
+    # 1. loading
     load_transforms = [
         LoadImaged(keys=keys, image_only=False),
         EnsureChannelFirstd(keys=keys),

--- a/modules/dynunet_pipeline/transforms.py
+++ b/modules/dynunet_pipeline/transforms.py
@@ -42,7 +42,7 @@ def get_task_transforms(mode, task_id, pos_sample_num, neg_sample_num, num_sampl
         keys = ["image"]
 
     load_transforms = [
-        LoadImaged(keys=keys),
+        LoadImaged(keys=keys, image_only=False, ensure_channel_first=True),
         EnsureChannelFirstd(keys=keys),
     ]
     # 2. sampling
@@ -284,6 +284,8 @@ class PreprocessAnisotropic(MapTransform):
 
     def calculate_new_shape(self, spacing, shape):
         spacing_ratio = np.array(spacing) / np.array(self.target_spacing)
+        if len(shape) == 4:  # If shape includes channel dimension
+            shape = shape[1:]
         new_shape = (spacing_ratio * np.array(shape)).astype(int).tolist()
         return new_shape
 

--- a/modules/dynunet_pipeline/transforms.py
+++ b/modules/dynunet_pipeline/transforms.py
@@ -42,7 +42,7 @@ def get_task_transforms(mode, task_id, pos_sample_num, neg_sample_num, num_sampl
         keys = ["image"]
 
     load_transforms = [
-        LoadImaged(keys=keys, image_only=False, ensure_channel_first=True),
+        LoadImaged(keys=keys, image_only=False),
         EnsureChannelFirstd(keys=keys),
     ]
     # 2. sampling


### PR DESCRIPTION
Fixes # .
handle metadata loading and shape calculation in transforms

### Description
- Add image_only=False and ensure_channel_first=True to LoadImaged transform to properly load metadata
- Fix shape mismatch in PreprocessAnisotropic.calculate_new_shape by handling 4D input shapes
- Addresses KeyError: 'image_meta_dict' and ValueError: operands could not be broadcast together

Note: The metadata loading issue might be related to MONAI version differences. 
Current version: 1.4.0

### Checks
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
