### PR TITLE
Fix documentation errors in tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each user is responsible for checking the content of datasets and the applicable
 
 ### 2. Questions and bugs
 
-- For questions relating to the use of MONAI, please us our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
+- For questions relating to the use of MONAI, please use our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
 - For bugs relating to MONAI functionality, please create an issue on the [main repository](https://github.com/Project-MONAI/MONAI/issues).
 - For bugs relating to the running of a tutorial, please create an issue in [this repository](https://github.com/Project-MONAI/Tutorials/issues).
 

--- a/deepedit/ignite/README.md
+++ b/deepedit/ignite/README.md
@@ -41,7 +41,7 @@ For this tutorial we used the public available dataset (Task09_Spleen) that can 
 
 ### 2. Questions and bugs
 
-- For questions relating to the use of MONAI, please us our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
+- For questions relating to the use of MONAI, please use our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
 
 - For bugs relating to MONAI functionality, please create an issue on the [main repository](https://github.com/Project-MONAI/MONAI/issues).
 

--- a/deepgrow/ignite/README.md
+++ b/deepgrow/ignite/README.md
@@ -16,7 +16,7 @@ Training a deepgrow model requires data. Some public available datasets which ar
 
 ### 2. Questions and bugs
 
-- For questions relating to the use of MONAI, please us our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
+- For questions relating to the use of MONAI, please use our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
 - For bugs relating to MONAI functionality, please create an issue on the [main repository](https://github.com/Project-MONAI/MONAI/issues).
 - For bugs relating to the running of a tutorial, please create an issue in [this repository](https://github.com/Project-MONAI/Tutorials/issues).
 

--- a/pathology/hovernet/README.MD
+++ b/pathology/hovernet/README.MD
@@ -15,7 +15,7 @@ CoNSeP datasets which are used in the examples are from <https://warwick.ac.uk/f
 
 ### 2. Questions and bugs
 
-- For questions relating to the use of MONAI, please us our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
+- For questions relating to the use of MONAI, please use our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
 - For bugs relating to MONAI functionality, please create an issue on the [main repository](https://github.com/Project-MONAI/MONAI/issues).
 - For bugs relating to the running of a tutorial, please create an issue in [this repository](https://github.com/Project-MONAI/Tutorials/issues).
 

--- a/pathology/nuclick/README.md
+++ b/pathology/nuclick/README.md
@@ -8,7 +8,7 @@ Training these model requires data. The datasets used in the examples are from [
 
 ### 2. Questions and bugs
 
-- For questions relating to the use of MONAI, please us our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
+- For questions relating to the use of MONAI, please use our [Discussions tab](https://github.com/Project-MONAI/MONAI/discussions) on the main repository of MONAI.
 - For bugs relating to MONAI functionality, please create an issue on the [main repository](https://github.com/Project-MONAI/MONAI/issues).
 - For bugs relating to the running of a tutorial, please create an issue in [this repository](https://github.com/Project-MONAI/Tutorials/issues).
 


### PR DESCRIPTION
Fixes # 2001.

### Description
README grammar fixes suggested by ChatGPT Codex

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Avoid including large-size files in the PR.
- [x] Clean up long text outputs from code cells in the notebook.
- [x] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [x] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [x] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`
