### PR TITLE
Updating Workflows to Fix Missing `pkg_resources`

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -8,34 +8,21 @@ on:
   pull_request:
 
 jobs:
-  # caching of these jobs:
-  #   - docker-20-03-py3-pip- (shared)
-  #   - ubuntu py37 pip-
-  #   - os-latest-pip- (shared)
   copyright:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.9
-    - name: cache weekly timestamp
-      id: pip-cache
-      run: |
-        echo "::set-output name=datew::$(date '+%Y-%V')"
-    - name: cache for pip
-      uses: actions/cache@v3
-      id: cache
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
+        python-version: 3.10
+        cache: 'pip'
     - name: Install dependencies
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         python -m pip install --upgrade pip wheel
-        python -m pip install -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
-        python -m pip install -r requirements.txt
+        pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
+        pip install -r requirements.txt
     - name: Copyright check
       run: |
         $(pwd)/runner.sh --no-run --no-checks --copyright

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -15,12 +15,12 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.10
+        python-version: '3.10'
         cache: 'pip'
     - name: Install dependencies
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel wheel-stub
         pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
         pip install -r requirements.txt
     - name: Copyright check

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -21,8 +21,7 @@ jobs:
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         python -m pip install --upgrade pip wheel wheel-stub
-        pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
     - name: Copyright check
       run: |
         $(pwd)/runner.sh --no-run --no-checks --copyright

--- a/.github/workflows/guidelines.yml
+++ b/.github/workflows/guidelines.yml
@@ -15,12 +15,12 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.10
+        python-version: '3.10'
         cache: 'pip'
     - name: Install dependencies
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel wheel-stub
         pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
         pip install -r requirements.txt
     - name: Guidelines notebook format check

--- a/.github/workflows/guidelines.yml
+++ b/.github/workflows/guidelines.yml
@@ -8,34 +8,21 @@ on:
   pull_request:
 
 jobs:
-  # caching of these jobs:
-  #   - docker-20-03-py3-pip- (shared)
-  #   - ubuntu py37 pip-
-  #   - os-latest-pip- (shared)
   guidelines:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.9
-    - name: cache weekly timestamp
-      id: pip-cache
-      run: |
-        echo "::set-output name=datew::$(date '+%Y-%V')"
-    - name: cache for pip
-      uses: actions/cache@v3
-      id: cache
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
+        python-version: 3.10
+        cache: 'pip'
     - name: Install dependencies
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         python -m pip install --upgrade pip wheel
-        python -m pip install -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
-        python -m pip install -r requirements.txt
+        pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
+        pip install -r requirements.txt
     - name: Guidelines notebook format check
       run: |
         $(pwd)/runner.sh --no-run --no-checks --cell-standard

--- a/.github/workflows/guidelines.yml
+++ b/.github/workflows/guidelines.yml
@@ -21,8 +21,7 @@ jobs:
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         python -m pip install --upgrade pip wheel wheel-stub
-        pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
     - name: Guidelines notebook format check
       run: |
         $(pwd)/runner.sh --no-run --no-checks --cell-standard

--- a/.github/workflows/pep8.yml
+++ b/.github/workflows/pep8.yml
@@ -8,34 +8,21 @@ on:
   pull_request:
 
 jobs:
-  # caching of these jobs:
-  #   - docker-20-03-py3-pip- (shared)
-  #   - ubuntu py37 pip-
-  #   - os-latest-pip- (shared)
   pep8:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.9
-    - name: cache weekly timestamp
-      id: pip-cache
-      run: |
-        echo "::set-output name=datew::$(date '+%Y-%V')"
-    - name: cache for pip
-      uses: actions/cache@v3
-      id: cache
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
+        python-version: 3.10
+        cache: 'pip'
     - name: Install dependencies
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         python -m pip install --upgrade pip wheel
-        python -m pip install -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
-        python -m pip install -r requirements.txt
+        pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
+        pip install -r requirements.txt
     - name: PEP8 check
       run: |
         $(pwd)/runner.sh --no-run

--- a/.github/workflows/pep8.yml
+++ b/.github/workflows/pep8.yml
@@ -21,8 +21,7 @@ jobs:
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         python -m pip install --upgrade pip wheel wheel-stub
-        pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
     - name: PEP8 check
       run: |
         $(pwd)/runner.sh --no-run

--- a/.github/workflows/pep8.yml
+++ b/.github/workflows/pep8.yml
@@ -15,12 +15,12 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.10
+        python-version: '3.10'
         cache: 'pip'
     - name: Install dependencies
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel wheel-stub
         pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
         pip install -r requirements.txt
     - name: PEP8 check

--- a/.github/workflows/test-modified.yml
+++ b/.github/workflows/test-modified.yml
@@ -16,11 +16,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
+        cache: 'pip'
     - name: Install MONAI
       id: monai-install
       env:
@@ -33,14 +34,14 @@ jobs:
         python -m pip install -U pip wheel
         # Force CPU-only PyTorch wheels so we don't download huge CUDA/nvidia-* wheels in CI.
         # Keep PyPI available for torch's dependencies.
-        python -m pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple torch torchvision torchaudio
+        pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple torch torchvision torchaudio
 
-        python -m pip install -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
-        python -m pip install -r requirements.txt
+        pip install --no-build-isolation -r https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/requirements-dev.txt
+        pip install -r requirements.txt
 
         # Avoid PEP517 build isolation (which can re-install torch and pull CUDA wheels).
-        BUILD_MONAI=0 python -m pip install --no-build-isolation git+https://github.com/Project-MONAI/MONAI#egg=MONAI
-        python -m pip list
+        BUILD_MONAI=0 pip install --no-build-isolation git+https://github.com/Project-MONAI/MONAI#egg=MONAI
+        pip list
     - name: Notebook quick check
       shell: bash
       run: |

--- a/.github/workflows/test-modified.yml
+++ b/.github/workflows/test-modified.yml
@@ -31,7 +31,7 @@ jobs:
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         df -h
         which python
-        python -m pip install -U pip wheel
+        python -m pip install -U pip wheel wheel-stub
         # Force CPU-only PyTorch wheels so we don't download huge CUDA/nvidia-* wheels in CI.
         # Keep PyPI available for torch's dependencies.
         pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple torch torchvision torchaudio


### PR DESCRIPTION
### Description
This updates the workflow files to fix changes to `setuptools` which drops support for `pkg_resources` but also removes the package from PyPI. With the `--no-build-isolation` flag added to `pip`, the version of `setuptools` in the installing environment is used, rather than a new one being installed in an isolated one which will be too new and fail when `pkg_resources` is found missing.

See https://github.com/Project-MONAI/MONAI/issues/8536.

### Checks
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Avoid including large-size files in the PR.
- [ ] Clean up long text outputs from code cells in the notebook.
- [ ] For security purposes, please check the contents and remove any sensitive info such as user names and private key.
- [ ] Ensure (1) hyperlinks and markdown anchors are working (2) use relative paths for tutorial repo files (3) put figure and graphs in the `./figure` folder
- [ ] Notebook runs automatically `./runner.sh -t <path to .ipynb file>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to newer action versions and upgraded Python runtime to 3.10
  * Simplified and consolidated dependency caching into a unified pip cache, removing legacy timestamp caching
  * Streamlined dependency installation and test/lint invocations (including upgraded packaging tooling and adjustments to build isolation) for more consistent and reliable CI runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->